### PR TITLE
Friends, Killaura tweak, more PlayerESP color schemes

### DIFF
--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -32,6 +32,7 @@ import net.wurstclient.navigator.Navigator;
 import net.wurstclient.other_feature.OtfList;
 import net.wurstclient.settings.SettingsFile;
 import net.wurstclient.update.WurstUpdater;
+import net.wurstclient.util.FriendsList;
 
 public enum WurstClient
 {
@@ -60,8 +61,9 @@ public enum WurstClient
 	private static boolean guiInitialized;
 	private WurstUpdater updater;
 	private Path wurstFolder;
-	
-	public void initialize()
+	private FriendsList friends;
+
+	public <friends> void initialize()
 	{
 		System.out.println("Starting Wurst Client...");
 		
@@ -93,6 +95,9 @@ public enum WurstClient
 		
 		Path preferencesFile = wurstFolder.resolve("preferences.json");
 		navigator = new Navigator(preferencesFile, hax, cmds, otfs);
+
+		Path friendsFile = wurstFolder.resolve("friends.json");
+		friends = new FriendsList(friendsFile);
 		
 		cmdProcessor = new CmdProcessor(cmds);
 		eventManager.add(ChatOutputListener.class, cmdProcessor);
@@ -217,5 +222,9 @@ public enum WurstClient
 	public Path getWurstFolder()
 	{
 		return wurstFolder;
+	}
+
+	public FriendsList getFriendsList() {
+		return friends;
 	}
 }

--- a/src/main/java/net/wurstclient/command/CmdList.java
+++ b/src/main/java/net/wurstclient/command/CmdList.java
@@ -64,6 +64,8 @@ public final class CmdList
 	// public final VClipCmd vClipCmd = new VClipCmd();
 	// public final WmsCmd wmsCmd = new WmsCmd();
 	// public final XRayCmd xRayCmd = new XRayCmd();
+
+	public final FCmd fCmd = new FCmd();
 	
 	private final TreeMap<String, Command> cmds =
 		new TreeMap<>((o1, o2) -> o1.compareToIgnoreCase(o2));

--- a/src/main/java/net/wurstclient/commands/FCmd.java
+++ b/src/main/java/net/wurstclient/commands/FCmd.java
@@ -1,0 +1,32 @@
+package net.wurstclient.commands;
+
+import net.wurstclient.command.CmdError;
+import net.wurstclient.command.CmdException;
+import net.wurstclient.command.Command;
+
+public class FCmd extends Command {
+	public FCmd() {
+		super("f", "List, add, or remove friends.", ".f [list|add|remove] <playername>");
+	}
+
+	@Override
+	public void call(String[] args) throws CmdException {
+		if (args.length < 1 || args.length > 2) throw new CmdError("Incorrect number of parameters passed!");
+
+		// TODO: Add a friends list.
+		switch (args[0].toLowerCase())
+		{
+			case "list":
+				System.out.println("LIST");
+				break;
+			case "add":
+				System.out.println("ADD");
+				break;
+			case "remove":
+				System.out.println("REMOVE");
+				break;
+			default:
+				throw new CmdError("First parameter must be \"list\", \"add\", or \"remove\".");
+		}
+	}
+}

--- a/src/main/java/net/wurstclient/commands/FCmd.java
+++ b/src/main/java/net/wurstclient/commands/FCmd.java
@@ -3,7 +3,9 @@ package net.wurstclient.commands;
 import net.wurstclient.WurstClient;
 import net.wurstclient.command.CmdError;
 import net.wurstclient.command.CmdException;
+import net.wurstclient.command.CmdSyntaxError;
 import net.wurstclient.command.Command;
+import net.wurstclient.util.ChatUtils;
 
 public class FCmd extends Command {
 	public FCmd() {
@@ -12,19 +14,27 @@ public class FCmd extends Command {
 
 	@Override
 	public void call(String[] args) throws CmdException {
-		if (args.length < 1 || args.length > 2) throw new CmdError("Incorrect number of parameters passed!");
-
+		if (args.length < 1 || args.length > 2)
+		{
+			throw new CmdSyntaxError();
+		}
 
 		switch (args[0].toLowerCase())
 		{
 			case "list":
-				System.out.println("LIST");
+				ChatUtils.message("These are your friends:");
+				for (String friend : WurstClient.INSTANCE.getFriendsList().getAllFriends())
+				{
+					ChatUtils.message(friend);
+				}
 				break;
 			case "add":
+				if (args.length < 2) throw new CmdError("No player supplied!");
 				WurstClient.INSTANCE.getFriendsList().addFriend(args[1]);
 				break;
 			case "remove":
-				System.out.println("REMOVE");
+				if (args.length < 2) throw new CmdError("No player supplied!");
+				WurstClient.INSTANCE.getFriendsList().removeFriend(args[1]);
 				break;
 			default:
 				throw new CmdError("First parameter must be \"list\", \"add\", or \"remove\".");

--- a/src/main/java/net/wurstclient/commands/FCmd.java
+++ b/src/main/java/net/wurstclient/commands/FCmd.java
@@ -1,5 +1,6 @@
 package net.wurstclient.commands;
 
+import net.wurstclient.WurstClient;
 import net.wurstclient.command.CmdError;
 import net.wurstclient.command.CmdException;
 import net.wurstclient.command.Command;
@@ -13,14 +14,14 @@ public class FCmd extends Command {
 	public void call(String[] args) throws CmdException {
 		if (args.length < 1 || args.length > 2) throw new CmdError("Incorrect number of parameters passed!");
 
-		// TODO: Add a friends list.
+
 		switch (args[0].toLowerCase())
 		{
 			case "list":
 				System.out.println("LIST");
 				break;
 			case "add":
-				System.out.println("ADD");
+				WurstClient.INSTANCE.getFriendsList().addFriend(args[1]);
 				break;
 			case "remove":
 				System.out.println("REMOVE");

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -8,10 +8,12 @@
 package net.wurstclient.hacks;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import net.wurstclient.WurstClient;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -60,6 +62,8 @@ public final class KillauraHack extends Hack
 	
 	private final CheckboxSetting filterPlayers = new CheckboxSetting(
 		"Filter players", "Won't attack other players.", false);
+	private final CheckboxSetting filterFriends = new CheckboxSetting(
+			"Filter friends", "Won't attack your friends", true);
 	private final CheckboxSetting filterSleeping = new CheckboxSetting(
 		"Filter sleeping", "Won't attack sleeping players.", false);
 	private final SliderSetting filterFlying =
@@ -103,6 +107,7 @@ public final class KillauraHack extends Hack
 		addSetting(range);
 		addSetting(priority);
 		addSetting(filterPlayers);
+		addSetting(filterFriends);
 		addSetting(filterSleeping);
 		addSetting(filterFlying);
 		addSetting(filterMonsters);
@@ -151,6 +156,12 @@ public final class KillauraHack extends Hack
 		
 		if(filterPlayers.isChecked())
 			stream = stream.filter(e -> !(e instanceof PlayerEntity));
+
+		if (filterFriends.isChecked())
+		{
+			List<String> friends = WurstClient.INSTANCE.getFriendsList().getAllFriends();
+			stream = stream.filter(e -> !friends.contains(e.getName().asString()));
+		}
 		
 		if(filterSleeping.isChecked())
 			stream = stream.filter(e -> !(e instanceof PlayerEntity

--- a/src/main/java/net/wurstclient/util/ColorCode.java
+++ b/src/main/java/net/wurstclient/util/ColorCode.java
@@ -1,0 +1,144 @@
+package net.wurstclient.util;
+
+/**
+ * Old class I wrote a long time ago. Takes either a RGB color set or a single colorcode, and maps it to a GL11-compatible RGB set between 0 and 1.
+ */
+public class ColorCode {
+	public float r, g, b;
+
+	// Given a set of RGB values, store it
+	public ColorCode(float r, float g, float b)
+	{
+		this.r = r/255;
+		this.g = g/255;
+		this.b = b/255;
+	}
+
+	// Given a color code, return a ColorCode object with rgb values.
+	public ColorCode(String colorstring)
+	{
+		//colorstring = String.valueOf(colorstring.charAt(1)); // Get second character only. It's the one with the data. Not needed because ListOfColorCodes returns w/o the section sign
+
+		switch(colorstring) {
+			// Stored between 0-255. Converted to scale 0-1 at bottom.
+
+			// Black
+			case "0":
+				r = 0;
+				g = 0;
+				b = 0;
+				break;
+
+			// Dark blue
+			case "1":
+				r = 0;
+				g = 0;
+				b = 170;
+				break;
+
+			// Dark green
+			case "2":
+				r = 0;
+				g = 170;
+				b = 0;
+				break;
+
+			// Dark aqua
+			case "3":
+				r = 0;
+				g = 170;
+				b = 170;
+				break;
+
+			// Dark red
+			case "4":
+				r = 170;
+				g = 0;
+				b = 0;
+				break;
+
+			// Dark purple
+			case "5":
+				r = 170;
+				g = 0;
+				b = 170;
+				break;
+
+			// Gold
+			case "6":
+				r = 255;
+				g = 170;
+				b = 0;
+				break;
+
+			// Gray
+			case "7":
+				r = 170;
+				g = 170;
+				b = 170;
+				break;
+
+			// Dark gray
+			case "8":
+				r = 85;
+				g = 85;
+				b = 85;
+				break;
+
+			// Blue
+			case "9":
+				r = 85;
+				g = 85;
+				b = 255;
+				break;
+
+			// Green
+			case "a":
+				r = 85;
+				g = 255;
+				b = 85;
+				break;
+
+			// Aqua
+			case "b":
+				r = 85;
+				g = 255;
+				b = 255;
+				break;
+
+			// Red
+			case "c":
+				r = 255;
+				g = 85;
+				b = 85;
+				break;
+
+			// Light purple
+			case "d":
+				r = 255;
+				g = 85;
+				b = 255;
+				break;
+
+			// Yellow
+			case "e":
+				r = 255;
+				g = 255;
+				b = 85;
+				break;
+
+			// White
+			case "f":
+				r = 255;
+				g = 255;
+				b = 255;
+				break;
+
+		}
+
+		// Translate to scale of 0-1.
+		r /= 255;
+		g /= 255;
+		b /= 255;
+	}
+}

--- a/src/main/java/net/wurstclient/util/FriendsList.java
+++ b/src/main/java/net/wurstclient/util/FriendsList.java
@@ -2,6 +2,7 @@ package net.wurstclient.util;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -18,13 +19,44 @@ public class FriendsList {
 	}
 
 	/**
-	 * Adds a friend, and saves them to a list.
+	 * Adds a friend, and saves them to a list. If the player already exists, they will not be re-added, and a message will be printed to chat.
 	 * @param playerName The name of the player to add as friend.
 	 */
 	public void addFriend(String playerName)
 	{
-		friends.add(playerName);
-		save();
+		if (friends.contains(playerName))
+		{
+			ChatUtils.message(playerName + " is already a friend!");
+		}
+		else
+		{
+			friends.add(playerName);
+			save();
+		}
+	}
+
+	/**
+	 * Removes a friend and then save the list. If the player does not exist, nothing will happen and a message will be printed.
+	 * @param playerName The name of the player to remove from the friends list.
+	 */
+	public void removeFriend(String playerName) {
+		if (friends.contains(playerName))
+		{
+			friends.remove(playerName);
+		}
+		else
+		{
+			ChatUtils.message(playerName + " is not a friend.");
+		}
+	}
+
+	/**
+	 * Gets a list of all friends. Attempts to add or remove from this will cause a crash.
+	 * @return A unmodifiable list of friends.
+	 */
+	public List<String> getAllFriends()
+	{
+		return Collections.unmodifiableList(friends);
 	}
 
 	/**
@@ -32,7 +64,7 @@ public class FriendsList {
 	 */
 	private void save()
 	{
-		System.out.println("TEST: Saved!");
+
 	}
 
 	/**

--- a/src/main/java/net/wurstclient/util/FriendsList.java
+++ b/src/main/java/net/wurstclient/util/FriendsList.java
@@ -1,0 +1,45 @@
+package net.wurstclient.util;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a list of friends, along with methods to save or load the list from disk.
+ */
+public class FriendsList {
+	private final List<String> friends = new ArrayList<>();
+	private Path friendsFile;
+
+	public FriendsList(Path friendsFile)
+	{
+		this.friendsFile = friendsFile;
+		load();
+	}
+
+	/**
+	 * Adds a friend, and saves them to a list.
+	 * @param playerName The name of the player to add as friend.
+	 */
+	public void addFriend(String playerName)
+	{
+		friends.add(playerName);
+		save();
+	}
+
+	/**
+	 * Save all friends in the list to the file at friendsFile.
+	 */
+	private void save()
+	{
+		System.out.println("TEST: Saved!");
+	}
+
+	/**
+	 * Loads all friends from file, and puts them in the list. If the file does not exist, a blank one will be created.
+	 */
+	private void load()
+	{
+
+	}
+}

--- a/src/main/java/net/wurstclient/util/FriendsList.java
+++ b/src/main/java/net/wurstclient/util/FriendsList.java
@@ -1,15 +1,27 @@
 package net.wurstclient.util;
 
+import com.google.gson.JsonArray;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.hack.HackList;
+import net.wurstclient.util.json.JsonException;
+import net.wurstclient.util.json.JsonUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Represents a list of friends, along with methods to save or load the list from disk.
  */
 public class FriendsList {
-	private final List<String> friends = new ArrayList<>();
+	private List<String> friends = new ArrayList<>();
 	private Path friendsFile;
 
 	public FriendsList(Path friendsFile)
@@ -43,6 +55,7 @@ public class FriendsList {
 		if (friends.contains(playerName))
 		{
 			friends.remove(playerName);
+			save();
 		}
 		else
 		{
@@ -60,11 +73,19 @@ public class FriendsList {
 	}
 
 	/**
-	 * Save all friends in the list to the file at friendsFile.
+	 * Save all friends in the list to the file at friendsFile. This file will be created if necessary.
 	 */
 	private void save()
 	{
-
+		try
+		{
+			JsonUtils.toJson(createJson(), friendsFile);
+		}
+		catch (JsonException | IOException e)
+		{
+			System.out.println("Error while trying to save friends list.");
+			e.printStackTrace();
+		}
 	}
 
 	/**
@@ -72,6 +93,24 @@ public class FriendsList {
 	 */
 	private void load()
 	{
+		try
+		{
+			friends = JsonUtils.parseFileToArray(friendsFile).getAllStrings();
+		} catch (IOException | JsonException e)
+		{
+			e.printStackTrace();
+		}
+	}
 
+	/**
+	 * Creates a JsonArray from the friends list.
+	 * @return A JsonArray
+	 */
+	private JsonArray createJson()
+	{
+		JsonArray json = new JsonArray();
+		friends.forEach(json::add);
+
+		return json;
 	}
 }


### PR DESCRIPTION
**Added Friends**
- Saved in wurst/friends.json
- Will auto-dedupe
- Syntax: .f [list|add|remove] <player>

**Patched KillAura**
- New option: Ignore friends

**Patched PlayerESP**
- Renamed old style to "Range". Still works as usual.
- Added new style "Fixed". All players are green, friends are blue.
- Added new style "Teams". Uses players' colorcodes and regex to attempt to figure out optimal color. Friends are rendered in rainbow.

(Note: I wrote the player color code for 1.12.2 a long time ago, so the code may be messier than usual. However, I cleaned it up a bit, and it still works just fine.)

**NOTE:** If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for us to add your features, as we have to test, validate and add them one by one.

Thank you for your understanding - and thanks again for taking the time to contribute!!
