### PR TITLE
Fixed crash on cleanup

### DIFF
--- a/src/main/java/net/wurstclient/serverfinder/CleanUpScreen.java
+++ b/src/main/java/net/wurstclient/serverfinder/CleanUpScreen.java
@@ -125,6 +125,7 @@ public class CleanUpScreen extends Screen
 		{
 			ServerEntry server = prevScreen.getServerList().get(i);
 			if(cleanupUnknown
+				&& server.label != null
 				&& server.label.equals("\u00a74Can\'t resolve hostname")
 				|| cleanupOutdated && server.protocolVersion != 498
 				|| cleanupFailed && server.ping != -2L && server.ping < 0L

--- a/src/main/java/net/wurstclient/serverfinder/CleanUpScreen.java
+++ b/src/main/java/net/wurstclient/serverfinder/CleanUpScreen.java
@@ -125,8 +125,7 @@ public class CleanUpScreen extends Screen
 		{
 			ServerEntry server = prevScreen.getServerList().get(i);
 			if(cleanupUnknown
-				&& server.label != null
-				&& server.label.equals("\u00a74Can\'t resolve hostname")
+				&& "\u00a74Can\'t resolve hostname".equals(server.label)
 				|| cleanupOutdated && server.protocolVersion != 498
 				|| cleanupFailed && server.ping != -2L && server.ping < 0L
 				|| cleanupGriefMe && server.name.startsWith("Grief me"))


### PR DESCRIPTION
Fixed a crash issue where server.label is null, so calling equals() will crash.

**NOTE:** If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for us to add your features, as we have to test, validate and add them one by one.

Thank you for your understanding - and thanks again for taking the time to contribute!!
