### PR TITLE
Update ZoomOtf.java

### DIFF
--- a/src/main/java/net/wurstclient/other_features/ZoomOtf.java
+++ b/src/main/java/net/wurstclient/other_features/ZoomOtf.java
@@ -7,6 +7,8 @@
  */
 package net.wurstclient.other_features;
 
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.options.GameOptions;
 import net.wurstclient.SearchTags;
 import net.wurstclient.events.MouseScrollListener;
 import net.wurstclient.other_feature.OtherFeature;
@@ -27,6 +29,8 @@ public final class ZoomOtf extends OtherFeature implements MouseScrollListener
 		true);
 	
 	private Double currentLevel;
+	private long zoomedTicks; // How many ticks zoom has occurred.
+	private double defaultMouseSensitivity;
 	
 	public ZoomOtf()
 	{
@@ -40,15 +44,31 @@ public final class ZoomOtf extends OtherFeature implements MouseScrollListener
 	
 	public double changeFovBasedOnZoom(double fov)
 	{
+		GameOptions gameOptions = MinecraftClient.getInstance().options;
+
 		if(currentLevel == null)
 			currentLevel = level.getValue();
 		
 		if(!WURST.getZoomKey().isPressed())
 		{
 			currentLevel = level.getValue();
+
+			if (zoomedTicks != 0) gameOptions.mouseSensitivity = defaultMouseSensitivity; // Runs once when zoom key is released
+			zoomedTicks = 0;
 			return fov;
 		}
-		
+
+		// Runs once when zoom key is pressed.
+		if (zoomedTicks == 0)
+		{
+			defaultMouseSensitivity = gameOptions.mouseSensitivity;
+		}
+
+		// Adjust mouse sensitivity in relation to zoom level. The final -0.01 helps when zooming in very far.
+		// (fov / currentLevel) / fov is a value between 0.02 and 1, with 1 being no zoom.
+		gameOptions.mouseSensitivity = defaultMouseSensitivity * ((fov / currentLevel) / fov) - 0.01;
+
+		zoomedTicks++;
 		return fov / currentLevel;
 	}
 	


### PR DESCRIPTION
Zoom scales mouse speed with zoom level, so high levels of zoom will not cause the camera to move wildly when moving the mouse.

**NOTE:** If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for us to add your features, as we have to test, validate and add them one by one.

Thank you for your understanding - and thanks again for taking the time to contribute!!
