### PR TITLE
MobESP crash fix

### DIFF
--- a/src/main/java/net/wurstclient/hacks/MobEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/MobEspHack.java
@@ -88,7 +88,7 @@ public final class MobEspHack extends Hack implements UpdateListener,
 		mobs.clear();
 		
 		Stream<MobEntity> stream =
-			StreamSupport.stream(MC.world.getEntities().spliterator(), true)
+			StreamSupport.stream(MC.world.getEntities().spliterator(), false)
 				.filter(e -> e instanceof MobEntity).map(e -> (MobEntity)e)
 				.filter(e -> !e.removed && e.getHealth() > 0);
 		


### PR DESCRIPTION
Fixed a bug which may cause the client to crash (hang/not responding) on servers such as Hypixel or Mineplex.

**NOTE:** If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for us to add your features, as we have to test, validate and add them one by one.

Thank you for your understanding - and thanks again for taking the time to contribute!!
