### PR TITLE
Add Vertical Strength and Horizontal Strength settings to AntiKnockback hack

### DIFF
--- a/src/main/java/net/wurstclient/hacks/AntiKnockbackHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiKnockbackHack.java
@@ -18,8 +18,12 @@ import net.wurstclient.settings.SliderSetting.ValueDisplay;
 	"no knockback", "AntiKB", "anti kb"})
 public final class AntiKnockbackHack extends Hack implements KnockbackListener
 {
-	private final SliderSetting strength = new SliderSetting("Strength",
-		"How far to reduce knockback.\n" + "100% = no knockback", 1, 0.01, 1,
+	private final SliderSetting verticalStrength = new SliderSetting("Vertical Strength",
+		"How far to reduce vertical knockback.\n" + "100% = no knockback", 1, 0.01, 1,
+		0.01, ValueDisplay.PERCENTAGE);
+
+	private final SliderSetting horizontalStrength = new SliderSetting("Horizonal Strength",
+		"How far to reduce horizontal knockback.\n" + "100% = no knockback", 1, 0.01, 1,
 		0.01, ValueDisplay.PERCENTAGE);
 	
 	public AntiKnockbackHack()
@@ -27,7 +31,8 @@ public final class AntiKnockbackHack extends Hack implements KnockbackListener
 		super("AntiKnockback",
 			"Prevents you from getting pushed by players and mobs.");
 		setCategory(Category.COMBAT);
-		addSetting(strength);
+		addSetting(verticalStrength);
+		addSetting(horizontalStrength);
 	}
 	
 	@Override
@@ -45,9 +50,10 @@ public final class AntiKnockbackHack extends Hack implements KnockbackListener
 	@Override
 	public void onKnockback(KnockbackEvent event)
 	{
-		double multiplier = 1 - strength.getValue();
-		event.setX(event.getDefaultX() * multiplier);
-		event.setY(event.getDefaultY() * multiplier);
-		event.setZ(event.getDefaultZ() * multiplier);
+		double verticalMultiplier = 1 - verticalStrength.getValue();
+		double horizontalMultiplier = 1 - horizontalStrength.getValue();
+		event.setX(event.getDefaultX() * horizontalMultiplier);
+		event.setY(event.getDefaultY() * verticalMultiplier);
+		event.setZ(event.getDefaultZ() * horizontalMultiplier);
 	}
 }


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
These settings help closet cheating. Vertical antikb is easily detectable, but horizontal antikb is harder to detect.