### PR TITLE
Fix auto mine BlockBreaker unhandled exception

### DIFF
--- a/src/main/java/net/wurstclient/util/BlockBreaker.java
+++ b/src/main/java/net/wurstclient/util/BlockBreaker.java
@@ -33,8 +33,20 @@ public enum BlockBreaker
 		Direction[] sides = Direction.values();
 		
 		Vec3d eyesPos = RotationUtils.getEyesPos();
-		Vec3d relCenter = BlockUtils.getState(pos)
-			.getOutlineShape(MC.world, pos).getBoundingBox().getCenter();
+		Vec3d relCenter;
+		try
+		{
+			relCenter = BlockUtils.getState(pos)
+					.getOutlineShape(MC.world, pos).getBoundingBox().getCenter();
+
+		}catch (UnsupportedOperationException e)
+		{
+			System.out.println(
+					"WARNING! BlockBreaker.breakOneBlock(); failed with the following exception:");
+			e.printStackTrace();
+			return false;
+		}
+
 		Vec3d center = new Vec3d(pos).add(relCenter);
 		
 		Vec3d[] hitVecs = new Vec3d[sides.length];


### PR DESCRIPTION
## Description
*This patch has been tested.*

When breaking empty block (air), getBounding from Minecraft generates following exception:
```
java.lang.UnsupportedOperationException: No bounds for empty shape.
	at net.minecraft.class_265.method_1107(class_265.java:48)
	at net.wurstclient.util.BlockBreaker.breakOneBlock(BlockBreaker.java:37)
	at net.wurstclient.hacks.AutoMineHack.breakCurrentBlock(AutoMineHack.java:78)
	at net.wurstclient.hacks.AutoMineHack.onUpdate(AutoMineHack.java:57)
	at net.wurstclient.events.UpdateListener$UpdateEvent.fire(UpdateListener.java:27)
	at net.wurstclient.event.EventManager.fire(EventManager.java:55)
	at net.minecraft.class_746.handler$zdp000$onTick(class_746.java:1278)
	at net.minecraft.class_746.method_5773(class_746.java:204)
	at net.minecraft.class_638.method_18646(class_638.java:180)
	at net.minecraft.class_1937.method_18472(class_1937.java:534)
	at net.minecraft.class_638.method_18116(class_638.java:151)
	at net.minecraft.class_310.method_1574(class_310.java:1467)
	at net.minecraft.class_310.method_1523(class_310.java:964)
	at net.minecraft.class_310.method_1514(class_310.java:619)
	at net.minecraft.client.main.Main.main(Main.java:204)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:193)
	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:138)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:26)
```