### PR TITLE
Add a setMaxLength to passwordBox

### DIFF
--- a/src/main/java/net/wurstclient/altmanager/screens/AltEditorScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AltEditorScreen.java
@@ -76,6 +76,7 @@ public abstract class AltEditorScreen extends Screen
 		
 		passwordBox =
 			new TextFieldWidget(font, width / 2 - 100, 100, 200, 20, "");
+		passwordBox.setMaxLength(128);
 		passwordBox.setText(getDefaultPassword());
 		passwordBox.setRenderTextProvider((text, int_1) -> {
 			String stars = "";


### PR DESCRIPTION
## Description
Currently the password box on the edit alt screen is set to a limit of 32 characters which is not long enough for some cases. i have a few accounts that have a 64 character password. By setting this box to 128 it will solve the issue of not being able to enter long passwords on the client.

I am aware that you are able to imports accounts with long passwords via a txt file but this is currently not possible through the client without this (or a similar) modification.