### PR TITLE
Fix SearchHack empty chunks

### DIFF
--- a/src/main/java/net/wurstclient/hacks/SearchHack.java
+++ b/src/main/java/net/wurstclient/hacks/SearchHack.java
@@ -36,6 +36,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.EmptyChunk;
 import net.wurstclient.Category;
 import net.wurstclient.events.PacketInputListener;
 import net.wurstclient.events.RenderListener;
@@ -271,7 +272,11 @@ public final class SearchHack extends Hack
 		
 		for(int x = center.x - chunkRange; x <= center.x + chunkRange; x++)
 			for(int z = center.z - chunkRange; z <= center.z + chunkRange; z++)
-				chunksInRange.add(MC.world.getChunk(x, z));
+			{
+				Chunk chunk = MC.world.getChunk(x, z);
+				if(!(chunk instanceof EmptyChunk))
+					chunksInRange.add(chunk);
+			}
 			
 		return chunksInRange;
 	}


### PR DESCRIPTION
Currently, Search does not check if the chunk at the location exists, leading to "empty" chunks being added. This PR fixes the issue by adding a check when chunks in range are loaded in.