### PR TITLE
Better Night Vision

### DIFF
--- a/src/main/java/net/wurstclient/hacks/FullbrightHack.java
+++ b/src/main/java/net/wurstclient/hacks/FullbrightHack.java
@@ -8,8 +8,6 @@
 package net.wurstclient.hacks;
 
 import net.minecraft.client.options.GameOptions;
-import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.entity.effect.StatusEffects;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.events.UpdateListener;
@@ -35,8 +33,6 @@ public final class FullbrightHack extends Hack implements UpdateListener
 			+ "Only works if \u00a76Method\u00a7r is set to \u00a76Gamma\u00a7r.",
 		true);
 	
-	private boolean hasAppliedNightVision;
-	
 	public FullbrightHack()
 	{
 		super("Fullbright", "Allows you to see in the dark.");
@@ -54,11 +50,6 @@ public final class FullbrightHack extends Hack implements UpdateListener
 			approachGamma(16);
 		else
 			approachGamma(0.5);
-		
-		if(isEnabled() && method.getSelected() == Method.NIGHT_VISION)
-			applyNightVision();
-		else
-			clearNightVision();
 	}
 	
 	private void approachGamma(double target)
@@ -79,20 +70,9 @@ public final class FullbrightHack extends Hack implements UpdateListener
 			options.gamma -= 0.5;
 	}
 	
-	private void applyNightVision()
+	public boolean isNightVisionActive()
 	{
-		MC.player.addStatusEffect(new StatusEffectInstance(
-			StatusEffects.NIGHT_VISION, 16360, 0, false, false));
-		hasAppliedNightVision = true;
-	}
-	
-	private void clearNightVision()
-	{
-		if(!hasAppliedNightVision)
-			return;
-		
-		MC.player.removeStatusEffectInternal(StatusEffects.NIGHT_VISION);
-		hasAppliedNightVision = false;
+		return isEnabled() && method.getSelected() == Method.NIGHT_VISION;
 	}
 	
 	private static enum Method

--- a/src/main/java/net/wurstclient/mixin/GameRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameRendererMixin.java
@@ -14,10 +14,12 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.options.GameOptions;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.resource.SynchronousResourceReloadListener;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -97,6 +99,16 @@ public abstract class GameRendererMixin
 			return MathHelper.lerp(delta, first, second);
 		
 		return 0;
+	}
+	
+	@Inject(at = {@At("HEAD")},
+		method = {
+			"getNightVisionStrength(Lnet/minecraft/entity/LivingEntity;F)F"},
+		cancellable = true)
+	private static void onNightVisionStrength(LivingEntity en, float f, CallbackInfoReturnable<Float> cir)
+	{
+		if(WurstClient.INSTANCE.getHax().fullbrightHack.isNightVisionActive())
+			cir.setReturnValue(1F);
 	}
 	
 	@Inject(at = {@At("HEAD")},

--- a/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffects;
+import net.wurstclient.WurstClient;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin
+{
+	@Inject(at = {@At("HEAD")},
+		method = {
+			"hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z"},
+		cancellable = true)
+	private void hasNightVisionStatus(StatusEffect effect, CallbackInfoReturnable<Boolean> cir)
+	{
+		LivingEntity en = (LivingEntity)(Object)this;
+		if(effect == StatusEffects.NIGHT_VISION
+			&& WurstClient.INSTANCE.getHax().fullbrightHack.isNightVisionActive()
+			&& en instanceof ClientPlayerEntity
+			&& en.getY() > 0)
+			cir.setReturnValue(true);
+	}
+}

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -35,6 +35,7 @@
     "InGameOverlayRendererMixin",
     "KeyBindingMixin",
     "KeyboardMixin",
+    "LivingEntityMixin",
     "LivingEntityRendererMixin",
     "MinecraftClientMixin",
     "MiningToolItemMixin",


### PR DESCRIPTION
Gives the night vision effect without the potion effect showing up.

This is helpful because if the player already has the night vision potion effect, toggling this mod wouldn't remove it.
