### PR TITLE
Better NoFire

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
@@ -10,10 +10,16 @@ package net.wurstclient.hacks;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.EnumSetting;
 
 @SearchTags({"no fire overlay"})
 public final class NoFireOverlayHack extends Hack
 {
+	private final EnumSetting<Mode> mode = new EnumSetting<>("Mode",
+		"\u00a7lLower\u00a7r mode shrinks the fire overlay.\n"
+			+ "\u00a7lNone\u00a7r mode removes the overlay.",
+		Mode.values(), Mode.LOWER);
+	
 	public NoFireOverlayHack()
 	{
 		super("NoFireOverlay",
@@ -22,5 +28,22 @@ public final class NoFireOverlayHack extends Hack
 				+ "to death without noticing.");
 		
 		setCategory(Category.RENDER);
+		addSetting(mode);
+	}
+	
+	public boolean shouldCancelOverlay()
+	{
+		return isEnabled() && mode.getSelected() == Mode.NONE;
+	}
+	
+	public boolean shouldLowerOverlay()
+	{
+		return isEnabled() && mode.getSelected() == Mode.LOWER;
+	}
+	
+	private enum Mode
+	{
+		LOWER,
+		NONE;
 	}
 }

--- a/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
@@ -16,14 +16,14 @@ import net.wurstclient.settings.EnumSetting;
 public final class NoFireOverlayHack extends Hack
 {
 	private final EnumSetting<Mode> mode = new EnumSetting<>("Mode",
-		"\u00a7lLower\u00a7r mode shrinks the fire overlay.\n"
-			+ "\u00a7lNone\u00a7r mode removes the overlay.",
+		"\u00a7lLower\u00a7r mode lowers the overlay.\n"
+			+ "\u00a7lRemove\u00a7r mode removes the overlay.",
 		Mode.values(), Mode.LOWER);
 	
 	public NoFireOverlayHack()
 	{
 		super("NoFireOverlay",
-			"Blocks the overlay when you are on fire.\n\n"
+			"Lowers or blocks the overlay when you are on fire.\n\n"
 				+ "\u00a7c\u00a7lWARNING:\u00a7r This can cause you to burn\n"
 				+ "to death without noticing.");
 		
@@ -33,7 +33,7 @@ public final class NoFireOverlayHack extends Hack
 	
 	public boolean shouldCancelOverlay()
 	{
-		return isEnabled() && mode.getSelected() == Mode.NONE;
+		return isEnabled() && mode.getSelected() == Mode.REMOVE;
 	}
 	
 	public boolean shouldLowerOverlay()
@@ -44,6 +44,6 @@ public final class NoFireOverlayHack extends Hack
 	private enum Mode
 	{
 		LOWER,
-		NONE;
+		REMOVE;
 	}
 }

--- a/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
@@ -9,7 +9,9 @@ package net.wurstclient.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.MinecraftClient;
@@ -27,8 +29,18 @@ public class InGameOverlayRendererMixin
 	private static void onRenderFireOverlay(MinecraftClient minecraftClient,
 		MatrixStack matrixStack, CallbackInfo ci)
 	{
-		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.isEnabled())
+		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.shouldCancelOverlay())
 			ci.cancel();
+	}
+	
+	@ModifyConstant(method =
+		"renderFireOverlay(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/util/math/MatrixStack;)V",
+		constant = @Constant(doubleValue = -0.30000001192092896D))
+	private static double getFireOffset(double orig)
+	{
+		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.shouldLowerOverlay())
+			return -0.5;
+		return orig;
 	}
 	
 	@Inject(at = {@At("HEAD")},


### PR DESCRIPTION
Adds an option to lower the fire overlay, which allows players to see that they are on fire without blocking half the screen.