### PR TITLE
[Critical] Prevent Servers from Running Wurst Commands

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ScreenMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
+
+@Mixin(Screen.class)
+public abstract class ScreenMixin
+{
+	@Shadow
+	protected MinecraftClient minecraft;
+	
+	@Inject(at = @At(value = "INVOKE",
+		target = "Lnet/minecraft/client/network/ClientPlayerEntity;sendChatMessage(Ljava/lang/String;)V",
+		ordinal = 0),
+		method = {
+			"sendMessage(Ljava/lang/String;Z)V"},
+		cancellable = true)
+	private void onSendChatMessage(String message, boolean toHud, CallbackInfo ci)
+	{
+		if(toHud)
+			return;
+		minecraft.getNetworkHandler().sendPacket(new ChatMessageC2SPacket(message));
+		ci.cancel();
+	}
+}

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -43,6 +43,7 @@
     "PlayerInventoryMixin",
     "PlayerSkinProviderMixin",
     "RenderTickCounterMixin",
+    "ScreenMixin",
     "ServerListMixin",
     "SignEditScreenMixin",
     "StatsScreenMixin",


### PR DESCRIPTION
Right now, a server is able to force a player into running a Wurst command through a chat message with a "ClickEvent" tag. This is already used to prevent the client from joining (#94), but a malicious server can easily mess with the client through chat messages. With this fix, all commands sent by clicking the chat message will bypass the Wurst command system.