### PR TITLE
Fixed AutoSign - 20w22a

### DIFF
--- a/src/main/java/net/wurstclient/hacks/AutoSignHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSignHack.java
@@ -17,7 +17,7 @@ import net.wurstclient.hack.Hack;
 @DontSaveState
 public final class AutoSignHack extends Hack
 {
-	private Text[] signText;
+	private String[] signText;
 	
 	public AutoSignHack()
 	{
@@ -34,12 +34,12 @@ public final class AutoSignHack extends Hack
 		signText = null;
 	}
 	
-	public Text[] getSignText()
+	public String[] getSignText()
 	{
 		return signText;
 	}
 	
-	public void setSignText(Text[] signText)
+	public void setSignText(String[] signText)
 	{
 		if(isEnabled() && this.signText == null)
 			this.signText = signText;

--- a/src/main/java/net/wurstclient/mixin/SignEditScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/SignEditScreenMixin.java
@@ -7,6 +7,7 @@
  */
 package net.wurstclient.mixin;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,6 +27,9 @@ public abstract class SignEditScreenMixin extends Screen
 {
 	@Shadow
 	private SignBlockEntity sign;
+
+	@Shadow @Final
+	private String[] field_24285;
 	
 	private SignEditScreenMixin(WurstClient wurst, Text text_1)
 	{
@@ -37,12 +41,12 @@ public abstract class SignEditScreenMixin extends Screen
 	{
 		AutoSignHack autoSignHack = WurstClient.INSTANCE.getHax().autoSignHack;
 		
-		Text[] autoSignText = autoSignHack.getSignText();
+		String[] autoSignText = autoSignHack.getSignText();
 		if(autoSignText == null)
 			return;
 		
 		for(int i = 0; i < 4; i++)
-			sign.setTextOnRow(i, autoSignText[i]);
+			field_24285[i] = autoSignText[i];
 		
 		finishEditing();
 	}
@@ -50,8 +54,7 @@ public abstract class SignEditScreenMixin extends Screen
 	@Inject(at = {@At("HEAD")}, method = {"finishEditing()V"})
 	private void onFinishEditing(CallbackInfo ci)
 	{
-		Text[] allRows = ((ISignBlockEntity)sign).getTextOnAllRows();
-		WurstClient.INSTANCE.getHax().autoSignHack.setSignText(allRows);
+		WurstClient.INSTANCE.getHax().autoSignHack.setSignText(field_24285);
 	}
 	
 	@Shadow


### PR DESCRIPTION
Was messing around in the 20w22a client and noticed AutoSign was broken.

Should mention that this fix doesn't use SignBlockEntityMixin or its interface, so if you aren't planning to use them for anything but AutoSign you might want to remove them.