### PR TITLE
Fixed HealthTagsHack causing no color on Hypixel and presumably other…

### DIFF
--- a/src/main/java/net/wurstclient/hacks/HealthTagsHack.java
+++ b/src/main/java/net/wurstclient/hacks/HealthTagsHack.java
@@ -8,6 +8,10 @@
 package net.wurstclient.hacks;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
@@ -21,26 +25,28 @@ public final class HealthTagsHack extends Hack
 		setCategory(Category.RENDER);
 	}
 	
-	public String addHealth(LivingEntity entity, String nametag)
+	public Text addHealth(LivingEntity entity, Text nametag)
 	{
 		if(!isEnabled())
 			return nametag;
 		
 		int health = (int)entity.getHealth();
-		return nametag + " " + getColor(health) + health;
+
+		MutableText formattedHealth = new LiteralText(" ").append(Integer.toString(health)).formatted(getColor(health));
+		return ((MutableText)nametag).append(formattedHealth);
 	}
 	
-	private String getColor(int health)
+	private Formatting getColor(int health)
 	{
 		if(health <= 5)
-			return "\u00a74";
+			return Formatting.DARK_RED;
 		
 		if(health <= 10)
-			return "\u00a76";
+			return Formatting.GOLD;
 		
 		if(health <= 15)
-			return "\u00a7e";
+			return Formatting.YELLOW;
 		
-		return "\u00a7a";
+		return Formatting.GREEN;
 	}
 }

--- a/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
@@ -43,8 +43,8 @@ public abstract class EntityRendererMixin<T extends Entity>
 		int i, CallbackInfo ci)
 	{
 		if(entity instanceof LivingEntity)
-			text = new LiteralText(WurstClient.INSTANCE.getHax().healthTagsHack
-				.addHealth((LivingEntity)entity, text.getString()));
+			text = WurstClient.INSTANCE.getHax().healthTagsHack
+				.addHealth((LivingEntity)entity, text);
 		
 		wurstRenderLabelIfPresent(entity, text, matrixStack,
 			vertexConsumerProvider, i);


### PR DESCRIPTION
… 1.16 servers

<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)

The update to 1.16 broke some string functions, namely the getString() function. In 1.15.2 and below, this returned the string including formatting codes. In newer versions, the formatting codes are no longer returned. As EntityRendererMixin's text variable is completely replaced with a function that takes in the original text, this new text lacks all formatting codes, except for the health tag color added by healthTagsHack.addHealth().

This can be overcome by sending the Text itself, instead of the string representation. This requires modification to the method signature of addHealth to accept and return Text instead of health.

At this point, we correctly send the text and have gained the ability to receive the text back with full formatting information.

We also need to modify the return of getColor(), as MutableText changes its formatting via Formatting codes.

This gets us the formatted color. We append this to the end of the player's healthtag. This fixes the issue.

Also, check out my pull request on adding an option to display the player's full health, which may be useful on servers where the max health is not 20.

## (Optional) screenshots / videos
If applicable, add screenshots or videos to help explain your pull request.

Before:
![2020 06 29 23 13 52](https://user-images.githubusercontent.com/30786211/86090196-82a89580-ba5e-11ea-93c3-a1cacee0d9bd.png)

After:
![2020 06 29 23 15 32](https://user-images.githubusercontent.com/30786211/86090211-889e7680-ba5e-11ea-9c86-aa4f0cdabbba.png)

