### PR TITLE
Added HideHacks

### DIFF
--- a/src/main/java/net/wurstclient/command/CmdList.java
+++ b/src/main/java/net/wurstclient/command/CmdList.java
@@ -39,6 +39,7 @@ public final class CmdList
 	public final GmCmd gmCmd = new GmCmd();
 	public final GoToCmd goToCmd = new GoToCmd();
 	public final HelpCmd helpCmd = new HelpCmd();
+	public final HackListCmd hackListCmd = new HackListCmd();
 	public final InvseeCmd invseeCmd = new InvseeCmd();
 	public final IpCmd ipCmd = new IpCmd();
 	public final JumpCmd jumpCmd = new JumpCmd();

--- a/src/main/java/net/wurstclient/commands/HackListCmd.java
+++ b/src/main/java/net/wurstclient/commands/HackListCmd.java
@@ -1,0 +1,142 @@
+package net.wurstclient.commands;
+
+import com.google.gson.JsonArray;
+import net.wurstclient.command.CmdError;
+import net.wurstclient.command.CmdException;
+import net.wurstclient.command.CmdSyntaxError;
+import net.wurstclient.command.Command;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.util.ChatUtils;
+import net.wurstclient.util.json.JsonException;
+import net.wurstclient.util.json.JsonUtils;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.TreeSet;
+
+public class HackListCmd extends Command {
+
+    private TreeSet<Hack> hiddenHacks = new TreeSet<>((hack1, hack2) -> hack1.getName().compareToIgnoreCase(hack2.getName()));
+    private final Path path;
+
+    public HackListCmd() {
+        super("hacklist",
+                "Collapse specific hacks into a numeric list to declutter your screen.",
+                "Add a hack: .hacklist hide <hackname>", "Remove a hack: .hacklist unhide <hackname> OR .hacklist show <hackname>", "List hidden hacks: .hacklist list");
+
+        path = WURST.getWurstFolder().resolve("hiddenhacklist.json");
+        load();
+    }
+
+    @Override
+    public void call(String[] args) throws CmdException {
+        if (args.length < 1)
+            throw new CmdSyntaxError();
+
+        // Listing hacks doesn't need another parameter, so put it above the two-argument check.
+        if (args[0].toLowerCase().equals("list"))
+        {
+            listHiddenHacks();
+            return;
+        }
+
+        if (args.length < 2)
+            throw new CmdSyntaxError();
+
+        if (WURST.getHax().getHackByName(args[1]) == null)
+            throw new CmdError("The specified hack does not exist.");
+
+        switch (args[0].toLowerCase()) {
+            case "hide":
+                hideHack(args[1]);
+                break;
+
+            case "unhide":
+            case "show":
+                unhideHack(args[1]);
+                break;
+
+            default:
+                throw new CmdSyntaxError("Only list, hide, and unhide/show subcommands are supported.");
+        }
+    }
+
+    private void hideHack(String hackName)
+    {
+        if (WURST.getHax().getHackByName(hackName) == null) return;
+
+        hiddenHacks.add(WURST.getHax().getHackByName(hackName));
+        save();
+    }
+
+    private void unhideHack(String hackName)
+    {
+        if (WURST.getHax().getHackByName(hackName) == null) return;
+
+        hiddenHacks.remove(WURST.getHax().getHackByName(hackName));
+        save();
+    }
+
+    private void listHiddenHacks()
+    {
+        StringBuilder sb = new StringBuilder("Hidden hacks: ");
+        for (Hack hack : hiddenHacks)
+            sb.append(hack.getName()).append(", ");
+
+
+        ChatUtils.message(sb.toString().replaceAll(", $", ""));
+    }
+
+    public TreeSet<Hack> getHiddenHacks()
+    {
+        return hiddenHacks;
+    }
+
+    public void load()
+    {
+        try
+        {
+            hiddenHacks.clear();
+
+            for (String hackName : JsonUtils.parseFileToArray(path).getAllStrings())
+            {
+                Hack hack = WURST.getHax().getHackByName(hackName);
+                if (hack == null)
+                    return;
+                hiddenHacks.add(hack);
+            }
+
+        }catch(NoSuchFileException e)
+        {
+            // The file doesn't exist yet. No problem, we'll create it later.
+
+        }catch(IOException | JsonException e)
+        {
+            System.out.println("Couldn't load " + path.getFileName());
+            e.printStackTrace();
+        }
+
+        save();
+    }
+
+    private void save()
+    {
+        try
+        {
+            JsonUtils.toJson(createJson(), path);
+
+        }catch(IOException | JsonException e)
+        {
+            System.out.println("Couldn't save " + path.getFileName());
+            e.printStackTrace();
+        }
+    }
+
+    private JsonArray createJson()
+    {
+        JsonArray json = new JsonArray();
+        hiddenHacks.forEach(hack -> json.add(hack.getName()));
+        return json;
+    }
+}

--- a/src/main/java/net/wurstclient/commands/HackListCmd.java
+++ b/src/main/java/net/wurstclient/commands/HackListCmd.java
@@ -34,11 +34,15 @@ public class HackListCmd extends Command {
         if (args.length < 1)
             throw new CmdSyntaxError();
 
-        // Listing hacks doesn't need another parameter, so put it above the two-argument check.
-        if (args[0].toLowerCase().equals("list"))
-        {
-            listHiddenHacks();
-            return;
+        // Listing hacks and removing all doesn't need another parameter, so put it above the two-argument check.
+        switch (args[0].toLowerCase()) {
+            case "list":
+                listHiddenHacks();
+                return;
+
+            case "unhide-all":
+                unhideAllHacks();
+                return;
         }
 
         if (args.length < 2)
@@ -58,7 +62,7 @@ public class HackListCmd extends Command {
                 break;
 
             default:
-                throw new CmdSyntaxError("Only list, hide, and unhide/show subcommands are supported.");
+                throw new CmdSyntaxError("Only list, hide, unhide/show, and unhide-all subcommands are supported.");
         }
     }
 
@@ -68,6 +72,8 @@ public class HackListCmd extends Command {
 
         hiddenHacks.add(WURST.getHax().getHackByName(hackName));
         save();
+
+        ChatUtils.message(hackName + " was added to the hidden hacks list.");
     }
 
     private void unhideHack(String hackName)
@@ -76,6 +82,15 @@ public class HackListCmd extends Command {
 
         hiddenHacks.remove(WURST.getHax().getHackByName(hackName));
         save();
+
+        ChatUtils.message(hackName + " was removed to the hidden hacks list.");
+    }
+
+    private void unhideAllHacks()
+    {
+        hiddenHacks.clear();
+
+        ChatUtils.message("Removed all hacks from the hidden hacks list.");
     }
 
     private void listHiddenHacks()

--- a/src/main/java/net/wurstclient/hud/HackListHUD.java
+++ b/src/main/java/net/wurstclient/hud/HackListHUD.java
@@ -83,6 +83,9 @@ public final class HackListHUD implements UpdateListener
 	{
 		TreeSet<Hack> hiddenHacks = WurstClient.INSTANCE.getCmds().hackListCmd.getHiddenHacks();
 
+		if (hiddenHacks.size() > 0)
+			drawHiddenHacksCount(matrixStack, hiddenHacks);
+
 		if(otf.isAnimations())
 		{
 			for(HackListEntry e : activeHax)
@@ -103,10 +106,6 @@ public final class HackListHUD implements UpdateListener
 				drawString(matrixStack, e.hack.getRenderName());
 			}
 		}
-
-		if (hiddenHacks.size() > 0)
-			drawHiddenHacksCount(matrixStack, hiddenHacks);
-
 	}
 	
 	public void updateState(Hack hack)

--- a/src/main/java/net/wurstclient/hud/HackListHUD.java
+++ b/src/main/java/net/wurstclient/hud/HackListHUD.java
@@ -199,7 +199,12 @@ public final class HackListHUD implements UpdateListener
 	{
 		TextRenderer tr = WurstClient.MC.textRenderer;
 
-		String s = hiddenHacks.size() + " hidden hack" + (hiddenHacks.size() == 1 ? "" : "s");
+		int enabledHacksCount = 0;
+		for (Hack hack : hiddenHacks)
+			if (hack.isEnabled())
+				enabledHacksCount++;
+
+		String s = hiddenHacks.size() + " hidden hack" + (hiddenHacks.size() == 1 ? "" : "s") + " (" + enabledHacksCount + " enabled)";
 
 		int posX;
 

--- a/src/main/java/net/wurstclient/hud/HackListHUD.java
+++ b/src/main/java/net/wurstclient/hud/HackListHUD.java
@@ -7,12 +7,6 @@
  */
 package net.wurstclient.hud;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.util.Window;
 import net.minecraft.client.util.math.MatrixStack;
@@ -22,6 +16,12 @@ import net.wurstclient.hack.Hack;
 import net.wurstclient.other_features.HackListOtf;
 import net.wurstclient.other_features.HackListOtf.Mode;
 import net.wurstclient.other_features.HackListOtf.Position;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.TreeSet;
 
 public final class HackListHUD implements UpdateListener
 {
@@ -81,12 +81,32 @@ public final class HackListHUD implements UpdateListener
 	
 	private void drawHackList(MatrixStack matrixStack, float partialTicks)
 	{
+		TreeSet<Hack> hiddenHacks = WurstClient.INSTANCE.getCmds().hackListCmd.getHiddenHacks();
+
 		if(otf.isAnimations())
+		{
 			for(HackListEntry e : activeHax)
+			{
+				if (hiddenHacks.contains(e.hack))
+					continue;
+
 				drawWithOffset(matrixStack, e, partialTicks);
+			}
+		}
 		else
+		{
 			for(HackListEntry e : activeHax)
+			{
+				if (hiddenHacks.contains(e.hack))
+					continue;
+
 				drawString(matrixStack, e.hack.getRenderName());
+			}
+		}
+
+		if (hiddenHacks.size() > 0)
+			drawHiddenHacksCount(matrixStack, hiddenHacks);
+
 	}
 	
 	public void updateState(Hack hack)
@@ -172,6 +192,29 @@ public final class HackListHUD implements UpdateListener
 		tr.draw(matrixStack, s, posX + 1, posY + 1, 0x04000000 | alpha);
 		tr.draw(matrixStack, s, posX, posY, textColor | alpha);
 		
+		posY += 9;
+	}
+
+	private void drawHiddenHacksCount(MatrixStack matrixStack, TreeSet<Hack> hiddenHacks)
+	{
+		TextRenderer tr = WurstClient.MC.textRenderer;
+
+		String s = hiddenHacks.size() + " hidden hack" + (hiddenHacks.size() == 1 ? "" : "s");
+
+		int posX;
+
+		if(otf.getPosition() == Position.LEFT)
+			posX = 2;
+		else
+		{
+			int screenWidth = WurstClient.MC.getWindow().getScaledWidth();
+			int stringWidth = tr.getWidth(s);
+
+			posX = screenWidth - stringWidth - 2;
+		}
+		tr.draw(matrixStack, s, posX + 1, posY + 1, 0xff000000);
+		tr.draw(matrixStack, s, posX, posY, textColor | 0xff000000);
+
 		posY += 9;
 	}
 	


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)
Added a command to enumerate certain hacks instead of listing them all. This can help declutter the screen by removing commonly used hacks, and only show ones that would be enabled or disabled based on the current situation.
The syntax is .hacklist <hide/unhide/show/list> [hackname]

## (Optional) screenshots / videos
If applicable, add screenshots or videos to help explain your pull request.

1. Too many hacks can clutter the screen. It may also make the scoreboard impossible to see.
![2020 07 01 18 08 24](https://user-images.githubusercontent.com/30786211/86305403-63c51300-bbc6-11ea-97db-77d7c836822d.png)

2. This hack can, based on a command, hide any hack using the aforementioned syntax, collapsing the listed hacks into this.
![2020 07 01 18 11 19](https://user-images.githubusercontent.com/30786211/86305471-8e16d080-bbc6-11ea-834e-33fb9f091026.png)

3. The hack saves the state across sessions. In addition, disabling and re-enabling a hack will not overwrite this command. The number of hidden hacks as well as the number of them that are enabled are both listed at the bottom of the list. In this case, I disabled the Trajectories and AntiBlind hack that was enabled from image 2.
![2020 07 01 18 11 46](https://user-images.githubusercontent.com/30786211/86305526-b8688e00-bbc6-11ea-930a-ca77f7ce01b3.png)
