### PR TITLE
AntiFabric Bypass

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientConnectionMixin.java
@@ -49,9 +49,9 @@ public abstract class ClientConnectionMixin
     public Packet<?> onSendPacket(Packet<?> packet)
     {
     	PacketOutputEvent event = new PacketOutputEvent(packet);
-		WurstClient.INSTANCE.getOtfs().vanillaSpoofOtf.onSentPacket(event);
-		this.event = event;
-		return event.getPacket();
+    	WurstClient.INSTANCE.getOtfs().vanillaSpoofOtf.onSentPacket(event);
+    	this.event = event;
+    	return event.getPacket();
     }
 	
 	@Inject(at = {@At(value = "HEAD")},

--- a/src/main/java/net/wurstclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientConnectionMixin.java
@@ -45,14 +45,14 @@ public abstract class ClientConnectionMixin
 			ci.cancel();
 	}
 	
-    @ModifyVariable(method = "send(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V", at = @At("HEAD"))
-    public Packet<?> onSendPacket(Packet<?> packet)
-    {
-    	PacketOutputEvent event = new PacketOutputEvent(packet);
-    	WurstClient.INSTANCE.getOtfs().vanillaSpoofOtf.onSentPacket(event);
-    	this.event = event;
-    	return event.getPacket();
-    }
+	@ModifyVariable(method = "send(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V", at = @At("HEAD"))
+	public Packet<?> onSendPacket(Packet<?> packet)
+	{
+		PacketOutputEvent event = new PacketOutputEvent(packet);
+		WurstClient.INSTANCE.getOtfs().vanillaSpoofOtf.onSentPacket(event);
+		this.event = event;
+		return event.getPacket();
+	}
 	
 	@Inject(at = {@At(value = "HEAD")},
 		method = {

--- a/src/main/java/net/wurstclient/other_feature/OtfList.java
+++ b/src/main/java/net/wurstclient/other_feature/OtfList.java
@@ -25,6 +25,7 @@ public final class OtfList
 	public final ReconnectOtf reconnectOtf = new ReconnectOtf();
 	public final ServerFinderOtf serverFinderOtf = new ServerFinderOtf();
 	public final TabGuiOtf tabGuiOtf = new TabGuiOtf();
+	public final VanillaSpoofOtf vanillaSpoofOtf = new VanillaSpoofOtf();
 	public final WurstCapesOtf wurstCapesOtf = new WurstCapesOtf();
 	public final WurstLogoOtf wurstLogoOtf = new WurstLogoOtf();
 	public final ZoomOtf zoomOtf = new ZoomOtf();

--- a/src/main/java/net/wurstclient/other_features/VanillaSpoofOtf.java
+++ b/src/main/java/net/wurstclient/other_features/VanillaSpoofOtf.java
@@ -38,7 +38,6 @@ public final class VanillaSpoofOtf extends OtherFeature
 			return;
 		
 		CustomPayloadC2SPacketAccessor packet = (CustomPayloadC2SPacketAccessor)event.getPacket();
-		System.out.println(packet.getChannel());
 		if(packet.getChannel().getNamespace().equals("minecraft") && packet.getChannel().getPath().equals("register"))
 			event.cancel();
 		

--- a/src/main/java/net/wurstclient/other_features/VanillaSpoofOtf.java
+++ b/src/main/java/net/wurstclient/other_features/VanillaSpoofOtf.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.other_features;
+
+import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.impl.networking.CustomPayloadC2SPacketAccessor;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.util.PacketByteBuf;
+import net.wurstclient.DontBlock;
+import net.wurstclient.events.PacketOutputListener.PacketOutputEvent;
+import net.wurstclient.other_feature.OtherFeature;
+import net.wurstclient.settings.CheckboxSetting;
+
+@DontBlock
+public final class VanillaSpoofOtf extends OtherFeature
+{
+	private final CheckboxSetting spoof = new CheckboxSetting("Spoof Vanilla", false);
+	
+	public VanillaSpoofOtf()
+	{
+		super("VanillaSpoof",
+			"Is your server blocking Fabric? This feature will help\n"
+			+ "you get around the block by pretending to be a vanilla client.");
+		addSetting(spoof);
+	}
+
+	public void onSentPacket(PacketOutputEvent event)
+	{
+		if(!spoof.isChecked())
+			return;
+		
+		if(!(event.getPacket() instanceof CustomPayloadC2SPacket))
+			return;
+		
+		CustomPayloadC2SPacketAccessor packet = (CustomPayloadC2SPacketAccessor)event.getPacket();
+		System.out.println(packet.getChannel());
+		if(packet.getChannel().getNamespace().equals("minecraft") && packet.getChannel().getPath().equals("register"))
+			event.cancel();
+		
+		if(packet.getChannel().getNamespace().equals("minecraft") && packet.getChannel().getPath().equals("brand"))
+			event.setPacket(new CustomPayloadC2SPacket(CustomPayloadC2SPacket.BRAND,
+				new PacketByteBuf(Unpooled.buffer()).writeString("vanilla")));
+		
+		if(packet.getChannel().getNamespace().equals("fabric"))
+			event.cancel();
+	}
+}


### PR DESCRIPTION
This feature allows Wurst to bypass servers that kick Fabric users. Since Fabric doesn't tell the server what mods it is using, some servers may opt to prevent Fabric clients from connecting.

Note: The mixin must be done from ClientConnection.class, otherwise not all the packets will be captured.