### PR TITLE
Fixed Skin Preview

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,27 +4,30 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
+
 ---
 
 ## Description
-What's wrong?
+A clear and concise description of what the bug is.
 
-## Steps To Reproduce
-Please make a list of steps to reproduce the problem (ideally from a fresh Wurst installation):
-1. 
-2. 
-3. 
+## Steps to reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
-## Screenshots / Videos (Optional)
-If applicable, add screenshots, videos or other files to help explain the problem.
+## (Optional) screenshots / videos
+If applicable, add screenshots or videos to help explain your problem.
 
-## Crash Report
-Please find your crash report file at "%appdata%/.minecraft/crash-reports", open the file in a text editor and copy-paste its content below.
+## Versions
+Please complete the following information:
+- Minecraft version: [e.g. 1.14.4]
+- Wurst version: [e.g. 7.0pre1]
 
+## Crash report
 ```
-
 (crash report goes here)
 
 ```
-
-**Please note:** If the game did not crash, please hold down F3+C for 10 seconds to generate a crash report. Even when a bug doesn't cause the game to crash, this file still contains useful information that can help us to find and fix the problem. Because of this, please always include a crash report.
+Please note: A log file or a picture of the launcher's "something went wrong" screen are _not_ the same as crash report. If the game didn't crash, please hold down F3+C for 10 seconds to generate a crash report.

--- a/src/main/java/net/wurstclient/altmanager/AltRenderer.java
+++ b/src/main/java/net/wurstclient/altmanager/AltRenderer.java
@@ -7,20 +7,18 @@
  */
 package net.wurstclient.altmanager;
 
-import java.io.IOException;
-import java.util.HashSet;
-
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
-import net.minecraft.client.texture.PlayerSkinTexture;
 import net.minecraft.client.util.DefaultSkinHelper;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 import net.wurstclient.WurstClient;
+import org.lwjgl.opengl.GL11;
+
+import java.io.IOException;
+import java.util.HashSet;
 
 public final class AltRenderer
 {
@@ -30,24 +28,28 @@ public final class AltRenderer
 	private static void bindSkinTexture(String name)
 	{
 		Identifier location = AbstractClientPlayerEntity.getSkinId(name);
-		
+
 		if(loadedSkins.contains(name))
 		{
 			mc.getTextureManager().bindTexture(location);
 			return;
 		}
-		
+
 		try
 		{
-			PlayerSkinTexture img =
-				AbstractClientPlayerEntity.loadSkin(location, name);
+			// Old API
+//			PlayerSkinTexture img =
+//					AbstractClientPlayerEntity.loadSkin(location, name);
+
+			PlayerSkinFetcher img = PlayerSkinFetcher.Fetch(location, name);
+
 			img.load(mc.getResourceManager());
-			
+
 		}catch(IOException e)
 		{
 			e.printStackTrace();
 		}
-		
+
 		mc.getTextureManager().bindTexture(location);
 		loadedSkins.add(name);
 	}

--- a/src/main/java/net/wurstclient/altmanager/PlayerSkinFetcher.java
+++ b/src/main/java/net/wurstclient/altmanager/PlayerSkinFetcher.java
@@ -1,0 +1,221 @@
+package net.wurstclient.altmanager;
+
+// Hi_ImKyle was here :)
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.texture.*;
+import net.minecraft.client.util.DefaultSkinHelper;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import net.wurstclient.util.SkinUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.concurrent.CompletableFuture;
+
+public class PlayerSkinFetcher extends ResourceTexture {
+    private static final Logger LOGGER = LogManager.getLogger();
+    @Nullable
+    private File cacheFile;
+    private String url;
+    private final boolean convertLegacy;
+    @Nullable
+    private final Runnable loadedCallback;
+    @Nullable
+    private CompletableFuture<?> loader;
+
+    public static PlayerSkinFetcher Fetch(Identifier id, String username) throws IOException {
+        TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
+        AbstractTexture abstractTexture = textureManager.getTexture(id);
+        if (abstractTexture == null) {
+            abstractTexture = new PlayerSkinFetcher((File)null, username, true, (Runnable)null);
+            textureManager.registerTexture(id, (AbstractTexture)abstractTexture);
+        }
+
+        return (PlayerSkinFetcher)abstractTexture;
+    }
+
+    public PlayerSkinFetcher(@Nullable File cacheFile, String username, boolean convertLegacy, @Nullable Runnable callback) throws IOException {
+        super(DefaultSkinHelper.getTexture(AbstractClientPlayerEntity.getOfflinePlayerUuid(username)));
+        this.cacheFile = cacheFile;
+        this.url = SkinUtils.getSkinUrl(username).toString();
+        this.convertLegacy = convertLegacy;
+        this.loadedCallback = callback;
+    }
+
+    private void onTextureLoaded(NativeImage image) {
+        if (this.loadedCallback != null) {
+            this.loadedCallback.run();
+        }
+
+        MinecraftClient.getInstance().execute(() -> {
+            if (!RenderSystem.isOnRenderThread()) {
+                RenderSystem.recordRenderCall(() -> {
+                    this.uploadTexture(image);
+                });
+            } else {
+                this.uploadTexture(image);
+            }
+
+        });
+    }
+
+    private void uploadTexture(NativeImage image) {
+        TextureUtil.allocate(this.getGlId(), image.getWidth(), image.getHeight());
+        image.upload(0, 0, 0, true);
+    }
+
+    public void load(ResourceManager manager) throws IOException {
+
+        // Causes extreme lag if the texture doesn't load as it continuously tries to load it.
+//        MinecraftClient.getInstance().execute(() -> {
+//            if (!this.loaded) {
+//                try {
+//                    super.load(manager);
+//                } catch (IOException var3) {
+//                    LOGGER.warn("Failed to load texture: {}", this.location, var3);
+//                }
+//
+//                this.loaded = true;
+//            }
+//
+//        });
+
+        if (this.loader == null) {
+            NativeImage nativeImage2;
+            if (this.cacheFile != null && this.cacheFile.isFile()) {
+                LOGGER.debug("Loading http texture from local cache ({})", this.cacheFile);
+                FileInputStream fileInputStream = new FileInputStream(this.cacheFile);
+                nativeImage2 = this.loadTexture(fileInputStream);
+            } else {
+                nativeImage2 = null;
+            }
+
+            if (nativeImage2 != null) {
+                this.onTextureLoaded(nativeImage2);
+            } else {
+                this.loader = CompletableFuture.runAsync(() -> {
+                    LOGGER.debug("Downloading http texture from {} to {}", this.url, this.cacheFile);
+
+                    try {
+
+                        Object inputStream2 = null;
+                        URLConnection conn = new URL(this.url).openConnection();
+                        try
+                        {
+                            inputStream2 = conn.getInputStream();
+                            if (this.cacheFile != null) {
+                                FileUtils.copyInputStreamToFile((InputStream) inputStream2, this.cacheFile);
+                            }
+                        }catch (IOException ioe){
+                            LOGGER.warn("Failed to get input stream for http texture");
+                        }
+
+                        Object finalInputStream = inputStream2;
+                        MinecraftClient.getInstance().execute(() -> {
+                            NativeImage nativeImage = this.loadTexture((InputStream) finalInputStream);
+                            if (nativeImage != null) {
+                                this.onTextureLoaded(nativeImage);
+                            }
+
+                        });
+                        return;
+                    } catch (Exception var6) {
+                        LOGGER.error("Couldn't download http texture", var6);
+                        return;
+                    }
+
+                }, Util.getServerWorkerExecutor());
+            }
+        }
+    }
+
+    @Nullable
+    private NativeImage loadTexture(InputStream stream) {
+        NativeImage nativeImage = null;
+
+        try {
+            nativeImage = NativeImage.read(stream);
+            if (this.convertLegacy) {
+                nativeImage = remapTexture(nativeImage);
+            }
+        } catch (IOException var4) {
+            LOGGER.warn("Error while loading the skin texture", var4);
+        }
+
+        return nativeImage;
+    }
+
+    private static NativeImage remapTexture(NativeImage image) {
+        boolean bl = image.getHeight() == 32;
+        if (bl) {
+            NativeImage nativeImage = new NativeImage(64, 64, true);
+            nativeImage.copyFrom(image);
+            image.close();
+            image = nativeImage;
+            nativeImage.fillRect(0, 32, 64, 32, 0);
+            nativeImage.copyRect(4, 16, 16, 32, 4, 4, true, false);
+            nativeImage.copyRect(8, 16, 16, 32, 4, 4, true, false);
+            nativeImage.copyRect(0, 20, 24, 32, 4, 12, true, false);
+            nativeImage.copyRect(4, 20, 16, 32, 4, 12, true, false);
+            nativeImage.copyRect(8, 20, 8, 32, 4, 12, true, false);
+            nativeImage.copyRect(12, 20, 16, 32, 4, 12, true, false);
+            nativeImage.copyRect(44, 16, -8, 32, 4, 4, true, false);
+            nativeImage.copyRect(48, 16, -8, 32, 4, 4, true, false);
+            nativeImage.copyRect(40, 20, 0, 32, 4, 12, true, false);
+            nativeImage.copyRect(44, 20, -8, 32, 4, 12, true, false);
+            nativeImage.copyRect(48, 20, -16, 32, 4, 12, true, false);
+            nativeImage.copyRect(52, 20, -8, 32, 4, 12, true, false);
+        }
+
+        stripAlpha(image, 0, 0, 32, 16);
+        if (bl) {
+            stripColor(image, 32, 0, 64, 32);
+        }
+
+        stripAlpha(image, 0, 16, 64, 32);
+        stripAlpha(image, 16, 48, 48, 64);
+        return image;
+    }
+
+    private static void stripColor(NativeImage image, int x, int y, int width, int height) {
+        int l;
+        int m;
+        for(l = x; l < width; ++l) {
+            for(m = y; m < height; ++m) {
+                int k = image.getPixelColor(l, m);
+                if ((k >> 24 & 255) < 128) {
+                    return;
+                }
+            }
+        }
+
+        for(l = x; l < width; ++l) {
+            for(m = y; m < height; ++m) {
+                image.setPixelColor(l, m, image.getPixelColor(l, m) & 16777215);
+            }
+        }
+
+    }
+
+    private static void stripAlpha(NativeImage image, int x, int y, int width, int height) {
+        for(int i = x; i < width; ++i) {
+            for(int j = y; j < height; ++j) {
+                image.setPixelColor(i, j, image.getPixelColor(i, j) | -16777216);
+            }
+        }
+
+    }
+}
+

--- a/src/main/java/net/wurstclient/altmanager/PlayerSkinFetcher.java
+++ b/src/main/java/net/wurstclient/altmanager/PlayerSkinFetcher.java
@@ -49,9 +49,17 @@ public class PlayerSkinFetcher extends ResourceTexture {
     public PlayerSkinFetcher(@Nullable File cacheFile, String username, boolean convertLegacy, @Nullable Runnable callback) throws IOException {
         super(DefaultSkinHelper.getTexture(AbstractClientPlayerEntity.getOfflinePlayerUuid(username)));
         this.cacheFile = cacheFile;
-        this.url = SkinUtils.getSkinUrl(username).toString();
         this.convertLegacy = convertLegacy;
         this.loadedCallback = callback;
+
+        // Check if the url exists in the first place, should prevent the following issue:
+        // https://github.com/Wurst-Imperium/Wurst7/pull/159#issuecomment-666946362
+        URL tempUrl = SkinUtils.getSkinUrl(username);
+        if(tempUrl == null){
+            this.url = null;
+            return;
+        }
+        this.url = tempUrl.toString();
     }
 
     private void onTextureLoaded(NativeImage image) {
@@ -91,6 +99,12 @@ public class PlayerSkinFetcher extends ResourceTexture {
 //            }
 //
 //        });
+
+        // Exit early if the skin url hasn't been found, either due to it being a Email or it just doesn't exist.
+        // https://github.com/Wurst-Imperium/Wurst7/pull/159#issuecomment-666946362
+        if(this.url == null) {
+            return;
+        }
 
         if (this.loader == null) {
             NativeImage nativeImage2;

--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -51,6 +51,7 @@ public final class HackList implements UpdateListener
 	public final AutoSprintHack autoSprintHack = new AutoSprintHack();
 	public final AutoStealHack autoStealHack = new AutoStealHack();
 	public final AutoSwimHack autoSwimHack = new AutoSwimHack();
+	public final AutoSwingHack autoSwingHack = new AutoSwingHack();
 	public final AutoSwitchHack autoSwitchHack = new AutoSwitchHack();
 	public final AutoSwordHack autoSwordHack = new AutoSwordHack();
 	public final AutoToolHack autoToolHack = new AutoToolHack();

--- a/src/main/java/net/wurstclient/hacks/AutoSwingHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSwingHack.java
@@ -1,0 +1,48 @@
+package net.wurstclient.hacks;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.wurstclient.Category;
+import net.wurstclient.events.BlockBreakingProgressListener;
+import net.wurstclient.events.UpdateListener;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
+
+public class AutoSwingHack extends Hack implements UpdateListener {
+
+    private final CheckboxSetting swingAnimation = new CheckboxSetting("Swing Animation",
+            "Whether or not to do the\n" + "swing animation.", true);
+
+    public AutoSwingHack() {
+        super("AutoSwing", "Continuously swings if you can hit an entity");
+        setCategory(Category.COMBAT);
+        addSetting(swingAnimation);
+    }
+
+    @Override
+    public void onUpdate() {
+        if (MC.options.keyAttack.isPressed() && MC.player != null && MC.player.getAttackCooldownProgress(0.0f) >= 1.0f && MC.crosshairTarget.getType() == HitResult.Type.ENTITY && swingAnimation.isChecked()) {
+            Entity e = ((EntityHitResult)MC.crosshairTarget).getEntity();
+            if(e.isAlive() && e.isAttackable()){
+                MC.interactionManager.attackEntity(MC.player, e);
+                if(swingAnimation.isChecked()) {
+                    MC.player.swingHand(Hand.MAIN_HAND);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onEnable()
+    {
+        EVENTS.add(UpdateListener.class, this);
+    }
+
+    @Override
+    public void onDisable()
+    {
+        EVENTS.remove(UpdateListener.class, this);
+    }
+}

--- a/src/main/java/net/wurstclient/util/SkinUtils.java
+++ b/src/main/java/net/wurstclient/util/SkinUtils.java
@@ -1,0 +1,122 @@
+package net.wurstclient.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class SkinUtils {
+
+    /**
+     * Returns the skin download URL for the given username.
+     */
+    public static URL getSkinUrl(String username) throws IOException
+    {
+        try{
+            String uuid = getUUID(username);
+            JsonObject texturesValueJson = getTexturesValue(uuid);
+
+            // Grab URL for skin
+            JsonObject tJObj = texturesValueJson.get("textures").getAsJsonObject();
+            JsonObject skinJObj = tJObj.get("SKIN").getAsJsonObject();
+            String skin = skinJObj.get("url").getAsString();
+
+            return URI.create(skin).toURL();
+        }catch (Exception ex){
+            return null;
+        }
+    }
+
+    /**
+     * Decodes the base64 textures value from {@link #getSessionJson(String)}.
+     * Once decoded, it looks like this:
+     *
+     * <code><pre>
+     * {
+     *   "timestamp" : &lt;current time&gt;,
+     *   "profileId" : "&lt;UUID&gt;",
+     *   "profileName" : "&lt;username&gt;",
+     *   "textures":
+     *   {
+     *     "SKIN":
+     *     {
+     *       "url": "http://textures.minecraft.net/texture/&lt;texture ID&gt;"
+     *     }
+     *   }
+     * }
+     * </pre></code>
+     */
+    private static JsonObject getTexturesValue(String uuid) throws IOException
+    {
+        JsonObject sessionJson = getSessionJson(uuid);
+
+        JsonArray propertiesJson =
+                sessionJson.get("properties").getAsJsonArray();
+        JsonObject firstProperty = propertiesJson.get(0).getAsJsonObject();
+        String texturesBase64 = firstProperty.get("value").getAsString();
+
+        byte[] texturesBytes = Base64.decodeBase64(texturesBase64.getBytes());
+        JsonObject texturesJson =
+                new Gson().fromJson(new String(texturesBytes), JsonObject.class);
+
+        return texturesJson;
+    }
+
+    /**
+     * Grabs the JSON code from the session server. It looks something like
+     * this:
+     *
+     * <code><pre>
+     * {
+     *   "id": "&lt;UUID&gt;",
+     *   "name": "&lt;username&gt;",
+     *   "properties":
+     *   [
+     *     {
+     *       "name": "textures",
+     *       "value": "&lt;base64 encoded JSON&gt;"
+     *     }
+     *   ]
+     * }
+     * </pre></code>
+     */
+    private static JsonObject getSessionJson(String uuid) throws IOException
+    {
+        URL sessionURL = URI
+                .create(
+                        "https://sessionserver.mojang.com/session/minecraft/profile/")
+                .resolve(uuid).toURL();
+
+        try(InputStream sessionInputStream = sessionURL.openStream())
+        {
+            return new Gson().fromJson(
+                    IOUtils.toString(sessionInputStream, StandardCharsets.UTF_8),
+                    JsonObject.class);
+        }
+    }
+
+    public static String getUUID(String username) throws IOException
+    {
+        URL profileURL =
+                URI.create("https://api.mojang.com/users/profiles/minecraft/")
+                        .resolve(username).toURL();
+
+        try(InputStream profileInputStream = profileURL.openStream())
+        {
+            // {"name":"<username>","id":"<UUID>"}
+
+            JsonObject profileJson = new Gson().fromJson(
+                    IOUtils.toString(profileInputStream, StandardCharsets.UTF_8),
+                    JsonObject.class);
+
+            return profileJson.get("id").getAsString();
+        }
+    }
+}


### PR DESCRIPTION
Fixed Skin Preview

 - Fixed Skin Preview on Alt Manager Screen
 - Skin Preview when adding an alt or editing an alt will not show if it's a Mojang Account
 - Moved New SkinAPI Related Methods to `SkinUtils`
 - Added AutoSwing Hack to swing if it's possible to hit an entity
 - Redid CLA thingy for the pull request

<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
`What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)`
Reimplemented the `PlayerSkinTexture` into `PlayerSkinFetcher` to accommodate for the skin API changes Mojang did a while back. This new skin fetcher uses the original methods the skin stealer used which are now located in `SkinUtils`

## (Optional) screenshots / videos
#154 for screenshots
