### PR TITLE
Fixed anti blind hack

### DIFF
--- a/src/main/java/net/wurstclient/mixin/BackgroundRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BackgroundRendererMixin.java
@@ -23,16 +23,24 @@ public class BackgroundRendererMixin
 	@Redirect(at = @At(value = "INVOKE",
 		target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z",
 		ordinal = 0),
-		method = {
-			"render(Lnet/minecraft/client/render/Camera;FLnet/minecraft/client/world/ClientWorld;IF)V",
-			"applyFog(Lnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/BackgroundRenderer$FogType;FZ)V"})
-	private static boolean wurstHasStatusEffect(LivingEntity entity,
-		StatusEffect effect)
+		method = "render(Lnet/minecraft/client/render/Camera;FLnet/minecraft/client/world/ClientWorld;IF)V")
+	private static boolean wurstHasStatusEffectRender(LivingEntity entity, StatusEffect effect)
 	{
-		if(effect == StatusEffects.BLINDNESS
-			&& WurstClient.INSTANCE.getHax().antiBlindHack.isEnabled())
+		if (effect == StatusEffects.BLINDNESS && WurstClient.INSTANCE.getHax().antiBlindHack.isEnabled())
 			return false;
-		
+
+		return entity.hasStatusEffect(effect);
+	}
+
+	@Redirect(at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z",
+			ordinal = 1),
+			method = "applyFog(Lnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/BackgroundRenderer$FogType;FZ)V")
+	private static boolean wurstHasStatusEffectApplyFog(LivingEntity entity, StatusEffect effect)
+	{
+		if (effect == StatusEffects.BLINDNESS && WurstClient.INSTANCE.getHax().antiBlindHack.isEnabled())
+			return false;
+
 		return entity.hasStatusEffect(effect);
 	}
 }


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)
Fixed anti blind hack. The mixin injection for applyFog has an incorrect ordinal.

## (Optional) screenshots / videos
If applicable, add screenshots or videos to help explain your pull request.

The anti-blind module does not work
![2020 08 27 15 04 04](https://user-images.githubusercontent.com/30786211/91499812-03c1b480-e877-11ea-8c6b-60fc1cfd166e.png)

The original mixin code looks like this
![2020 08 27 15 05 35](https://user-images.githubusercontent.com/30786211/91499856-1a680b80-e877-11ea-97cb-ecbfff0e5678.png)

Note that the ordinal value applies to both methods
This works fine for render, but for applyFog...
![2020 08 27 15 04 36](https://user-images.githubusercontent.com/30786211/91499971-59965c80-e877-11ea-842a-7b113dcb728a.png)

We need an ordinal of 1. We can also probably dispense with the blindness check, or write an error to log if we detect a status effect that is not blindness (in this case, for example, fire resist)
So we split the methods, and apply the patch on applyFog at ordinal 1
![2020 08 27 15 05 59](https://user-images.githubusercontent.com/30786211/91500079-99f5da80-e877-11ea-8ded-edd638ed8352.png)

And, success!
![2020 08 27 15 06 56](https://user-images.githubusercontent.com/30786211/91500104-a4b06f80-e877-11ea-8bf4-e4cfb05249cd.png)




