### PR TITLE
Fix scrolling past default GUI end causes crash

### DIFF
--- a/src/main/java/net/wurstclient/navigator/NavigatorMainScreen.java
+++ b/src/main/java/net/wurstclient/navigator/NavigatorMainScreen.java
@@ -137,9 +137,11 @@ public final class NavigatorMainScreen extends NavigatorScreen
 				clickTimer++;
 			else
 			{
-				Feature feature = navigatorDisplayList.get(hoveredFeature);
-				WurstClient.MC
-					.openScreen(new NavigatorFeatureScreen(feature, this));
+				if (0 <= hoveredFeature && hoveredFeature < navigatorDisplayList.size()) {
+					Feature feature = navigatorDisplayList.get(hoveredFeature);
+					WurstClient.MC
+						.openScreen(new NavigatorFeatureScreen(feature, this));
+				}
 			}
 		else if(!expanding && clickTimer > -1)
 			clickTimer--;


### PR DESCRIPTION
## Description
Fixes issue #182.
I added some checks before accessing the list.

## (Optional) screenshots / videos
not applicable.