### PR TITLE
1.16.3 entityesp

### DIFF
--- a/src/main/java/net/wurstclient/clickgui/components/EntityListEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/EntityListEditButton.java
@@ -12,9 +12,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.wurstclient.WurstClient;
 import net.wurstclient.clickgui.ClickGui;
 import net.wurstclient.clickgui.Component;
-import net.wurstclient.clickgui.screens.EditBlockListScreen;
 import net.wurstclient.clickgui.screens.EditEntityListScreen;
-import net.wurstclient.settings.BlockListSetting;
 import net.wurstclient.settings.EntityListSetting;
 import org.lwjgl.opengl.GL11;
 

--- a/src/main/java/net/wurstclient/clickgui/components/EntityListEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/EntityListEditButton.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.clickgui.components;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.wurstclient.WurstClient;
+import net.wurstclient.clickgui.ClickGui;
+import net.wurstclient.clickgui.Component;
+import net.wurstclient.clickgui.screens.EditBlockListScreen;
+import net.wurstclient.clickgui.screens.EditEntityListScreen;
+import net.wurstclient.settings.BlockListSetting;
+import net.wurstclient.settings.EntityListSetting;
+import org.lwjgl.opengl.GL11;
+
+public final class EntityListEditButton extends Component
+{
+	private final EntityListSetting setting;
+	private int buttonWidth;
+	
+	public EntityListEditButton(EntityListSetting setting)
+	{
+		this.setting = setting;
+		
+		TextRenderer fr = WurstClient.MC.textRenderer;
+		buttonWidth = fr.getWidth("Edit...");
+		
+		setWidth(getDefaultWidth());
+		setHeight(getDefaultHeight());
+	}
+	
+	@Override
+	public void handleMouseClick(double mouseX, double mouseY, int mouseButton)
+	{
+		if(mouseButton != 0)
+			return;
+		
+		if(mouseX < getX() + getWidth() - buttonWidth - 4)
+			return;
+		
+		WurstClient.MC.openScreen(
+			new EditEntityListScreen(WurstClient.MC.currentScreen, setting));
+	}
+	
+	@Override
+	public void render(MatrixStack matrixStack, int mouseX, int mouseY,
+		float partialTicks)
+	{
+		ClickGui gui = WurstClient.INSTANCE.getGui();
+		float[] bgColor = gui.getBgColor();
+		float[] acColor = gui.getAcColor();
+		float opacity = gui.getOpacity();
+		
+		int x1 = getX();
+		int x2 = x1 + getWidth();
+		int x3 = x2 - buttonWidth - 4;
+		int y1 = getY();
+		int y2 = y1 + getHeight();
+		
+		int scroll = getParent().isScrollingEnabled()
+			? getParent().getScrollOffset() : 0;
+		boolean hovering = mouseX >= x1 && mouseY >= y1 && mouseX < x2
+			&& mouseY < y2 && mouseY >= -scroll
+			&& mouseY < getParent().getHeight() - 13 - scroll;
+		boolean hText = hovering && mouseX < x3;
+		boolean hBox = hovering && mouseX >= x3;
+		
+		// tooltip
+		if(hText)
+			gui.setTooltip(setting.getDescription());
+		
+		// background
+		GL11.glColor4f(bgColor[0], bgColor[1], bgColor[2], opacity);
+		GL11.glBegin(GL11.GL_QUADS);
+		GL11.glVertex2i(x1, y1);
+		GL11.glVertex2i(x1, y2);
+		GL11.glVertex2i(x3, y2);
+		GL11.glVertex2i(x3, y1);
+		GL11.glEnd();
+		
+		// box
+		GL11.glColor4f(bgColor[0], bgColor[1], bgColor[2],
+			hBox ? opacity * 1.5F : opacity);
+		GL11.glBegin(GL11.GL_QUADS);
+		GL11.glVertex2i(x3, y1);
+		GL11.glVertex2i(x3, y2);
+		GL11.glVertex2i(x2, y2);
+		GL11.glVertex2i(x2, y1);
+		GL11.glEnd();
+		GL11.glColor4f(acColor[0], acColor[1], acColor[2], 0.5F);
+		GL11.glBegin(GL11.GL_LINE_LOOP);
+		GL11.glVertex2i(x3, y1);
+		GL11.glVertex2i(x3, y2);
+		GL11.glVertex2i(x2, y2);
+		GL11.glVertex2i(x2, y1);
+		GL11.glEnd();
+		
+		// setting name
+		GL11.glColor4f(1, 1, 1, 1);
+		GL11.glEnable(GL11.GL_TEXTURE_2D);
+		TextRenderer fr = WurstClient.MC.textRenderer;
+		String text = setting.getName() + ": " + setting.getEntityNames().size();
+		fr.draw(matrixStack, text, x1, y1 + 2, 0xf0f0f0);
+		fr.draw(matrixStack, "Edit...", x3 + 2, y1 + 2, 0xf0f0f0);
+		GL11.glDisable(GL11.GL_TEXTURE_2D);
+		GL11.glEnable(GL11.GL_BLEND);
+	}
+	
+	@Override
+	public int getDefaultWidth()
+	{
+		TextRenderer fr = WurstClient.MC.textRenderer;
+		String text = setting.getName() + ": " + setting.getEntityNames().size();
+		return fr.getWidth(text) + buttonWidth + 6;
+	}
+	
+	@Override
+	public int getDefaultHeight()
+	{
+		return 11;
+	}
+}

--- a/src/main/java/net/wurstclient/clickgui/screens/EditEntityListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditEntityListScreen.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.clickgui.screens;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.render.DiffuseLighting;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.util.registry.Registry;
+import net.wurstclient.settings.BlockListSetting;
+import net.wurstclient.settings.EntityListSetting;
+import net.wurstclient.util.BlockUtils;
+import net.wurstclient.util.EntityUtils;
+import net.wurstclient.util.ListWidget;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.opengl.GL11;
+
+import java.awt.*;
+import java.util.List;
+
+public final class EditEntityListScreen extends Screen
+{
+	private final Screen prevScreen;
+	private final EntityListSetting entityList;
+	
+	private ListGui listGui;
+	private TextFieldWidget entityNameField;
+	private ButtonWidget addButton;
+	private ButtonWidget removeButton;
+	private ButtonWidget doneButton;
+	
+	private EntityType<?> entityToAdd;
+	
+	public EditEntityListScreen(Screen prevScreen, EntityListSetting entityList)
+	{
+		super(new LiteralText(""));
+		this.prevScreen = prevScreen;
+		this.entityList = entityList;
+	}
+	
+	@Override
+	public boolean isPauseScreen()
+	{
+		return false;
+	}
+	
+	@Override
+	public void init()
+	{
+		listGui = new ListGui(client, this, entityList.getEntityNames());
+		
+		entityNameField = new TextFieldWidget(client.textRenderer,
+			width / 2 - 152, height - 55, 150, 18, new LiteralText(""));
+		children.add(entityNameField);
+		
+		addButton(addButton = new ButtonWidget(width / 2 - 2, height - 56, 30,
+			20, new LiteralText("Add"), b -> {
+				entityList.add(entityToAdd);
+				entityNameField.setText("");
+			}));
+		
+		addButton(removeButton = new ButtonWidget(width / 2 + 52, height - 56,
+			100, 20, new LiteralText("Remove Selected"),
+			b -> entityList.remove(listGui.selected)));
+		
+		addButton(new ButtonWidget(width - 108, 8, 100, 20,
+			new LiteralText("Reset to Defaults"),
+			b -> client.openScreen(new ConfirmScreen(b2 -> {
+				if(b2)
+					entityList.resetToDefaults();
+				client.openScreen(EditEntityListScreen.this);
+			}, new LiteralText("Reset to Defaults"),
+				new LiteralText("Are you sure?")))));
+		
+		addButton(
+			doneButton = new ButtonWidget(width / 2 - 100, height - 28, 200, 20,
+				new LiteralText("Done"), b -> client.openScreen(prevScreen)));
+	}
+	
+	@Override
+	public boolean mouseClicked(double mouseX, double mouseY, int mouseButton)
+	{
+		boolean childClicked = super.mouseClicked(mouseX, mouseY, mouseButton);
+		
+		entityNameField.mouseClicked(mouseX, mouseY, mouseButton);
+		listGui.mouseClicked(mouseX, mouseY, mouseButton);
+		
+		if(!childClicked && (mouseX < (width - 220) / 2
+			|| mouseX > width / 2 + 129 || mouseY < 32 || mouseY > height - 64))
+			listGui.selected = -1;
+		
+		return childClicked;
+	}
+	
+	@Override
+	public boolean mouseDragged(double double_1, double double_2, int int_1,
+		double double_3, double double_4)
+	{
+		listGui.mouseDragged(double_1, double_2, int_1, double_3, double_4);
+		return super.mouseDragged(double_1, double_2, int_1, double_3,
+			double_4);
+	}
+	
+	@Override
+	public boolean mouseReleased(double double_1, double double_2, int int_1)
+	{
+		listGui.mouseReleased(double_1, double_2, int_1);
+		return super.mouseReleased(double_1, double_2, int_1);
+	}
+	
+	@Override
+	public boolean mouseScrolled(double double_1, double double_2,
+		double double_3)
+	{
+		listGui.mouseScrolled(double_1, double_2, double_3);
+		return super.mouseScrolled(double_1, double_2, double_3);
+	}
+	
+	@Override
+	public boolean keyPressed(int keyCode, int scanCode, int int_3)
+	{
+		if(keyCode == GLFW.GLFW_KEY_ENTER)
+			addButton.onPress();
+		else if(keyCode == GLFW.GLFW_KEY_DELETE)
+			removeButton.onPress();
+		else if(keyCode == GLFW.GLFW_KEY_ESCAPE)
+			doneButton.onPress();
+		
+		return super.keyPressed(keyCode, scanCode, int_3);
+	}
+	
+	@Override
+	public void tick()
+	{
+		entityNameField.tick();
+		
+		entityToAdd = EntityUtils.getEntityTypeFromName(entityNameField.getText().toLowerCase());
+		addButton.active = entityToAdd != null;
+		
+		removeButton.active =
+			listGui.selected >= 0 && listGui.selected < listGui.list.size();
+	}
+	
+	@Override
+	public void render(MatrixStack matrixStack, int mouseX, int mouseY,
+		float partialTicks)
+	{
+		renderBackground(matrixStack);
+		listGui.render(matrixStack, mouseX, mouseY, partialTicks);
+		
+		drawCenteredString(matrixStack, client.textRenderer,
+			entityList.getName() + " (" + listGui.getItemCount() + ")",
+			width / 2, 12, 0xffffff);
+		
+		entityNameField.render(matrixStack, mouseX, mouseY, partialTicks);
+		super.render(matrixStack, mouseX, mouseY, partialTicks);
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(-64 + width / 2 - 152, 0, 0);
+		GL11.glTranslated(0, 0, 300);
+		
+		if(entityNameField.getText().isEmpty() && !entityNameField.isFocused())
+			drawStringWithShadow(matrixStack, client.textRenderer,
+				"Entity name or ID", 68, height - 50, 0x808080);
+		
+		fill(matrixStack, 48, height - 56, 64, height - 36, 0xffa0a0a0);
+		fill(matrixStack, 49, height - 55, 64, height - 37, 0xff000000);
+		fill(matrixStack, 214, height - 56, 244, height - 55, 0xffa0a0a0);
+		fill(matrixStack, 214, height - 37, 244, height - 36, 0xffa0a0a0);
+		fill(matrixStack, 244, height - 56, 246, height - 36, 0xffa0a0a0);
+		fill(matrixStack, 214, height - 55, 243, height - 52, 0xff000000);
+		fill(matrixStack, 214, height - 40, 243, height - 37, 0xff000000);
+		fill(matrixStack, 214, height - 55, 216, height - 37, 0xff000000);
+		fill(matrixStack, 242, height - 55, 245, height - 37, 0xff000000);
+		listGui.renderIconAndGetName(matrixStack, entityToAdd, 52,
+			height - 52, false);
+		
+		GL11.glPopMatrix();
+	}
+	
+	private static class ListGui extends ListWidget
+	{
+		private final MinecraftClient mc;
+		private final List<String> list;
+		private int selected = -1;
+		
+		public ListGui(MinecraftClient mc, EditEntityListScreen screen,
+			List<String> list)
+		{
+			super(mc, screen.width, screen.height, 32, screen.height - 64, 20);
+			this.mc = mc;
+			this.list = list;
+		}
+		
+		@Override
+		protected int getItemCount()
+		{
+			return list.size();
+		}
+		
+		@Override
+		protected boolean selectItem(int index, int int_2, double var3,
+			double var4)
+		{
+			if(index >= 0 && index < list.size())
+				selected = index;
+			
+			return true;
+		}
+		
+		@Override
+		protected boolean isSelectedItem(int index)
+		{
+			return index == selected;
+		}
+		
+		@Override
+		protected void renderBackground()
+		{
+			
+		}
+		
+		@Override
+		protected void renderItem(MatrixStack matrixStack, int index, int x,
+			int y, int var4, int var5, int var6, float partialTicks)
+		{
+			String name = list.get(index);
+			EntityType<?> entityType = EntityUtils.getEntityTypeFromName(name);
+			if (entityType == null)
+				return;
+			
+			TextRenderer fr = mc.textRenderer;
+			
+			//String displayName =
+			//	renderIconAndGetName(matrixStack, entityType, x + 1, y + 1, true);
+			fr.draw(matrixStack, entityType.getName().getString(), x, y, 0xf0f0f0);
+			fr.draw(matrixStack, "ID: " + name,
+				x, y + 9, 0xa0a0a0);
+		}
+		
+		private String renderIconAndGetName(MatrixStack matrixStack,
+			EntityType<?> entityType, int x, int y, boolean large)
+		{
+			if(entityType == null)
+			{
+				GL11.glPushMatrix();
+				GL11.glTranslated(x, y, 0);
+				if(large)
+					GL11.glScaled(1.5, 1.5, 1.5);
+				else
+					GL11.glScaled(0.75, 0.75, 0.75);
+					
+				DiffuseLighting.enable();
+				mc.getItemRenderer().renderInGuiWithOverrides(
+					new ItemStack(Blocks.GRASS_BLOCK), 0, 0);
+				DiffuseLighting.disable();
+				GL11.glPopMatrix();
+				
+				GL11.glPushMatrix();
+				GL11.glTranslated(x, y, 0);
+				if(large)
+					GL11.glScaled(2, 2, 2);
+				GL11.glDisable(GL11.GL_DEPTH_TEST);
+				TextRenderer fr = mc.textRenderer;
+				fr.drawWithShadow(matrixStack, "?", 3, 2, 0xf0f0f0);
+				GL11.glEnable(GL11.GL_DEPTH_TEST);
+				GL11.glPopMatrix();
+				
+				return "\u00a7ounknown entity\u00a7r";
+				
+			}else
+			{
+				GL11.glPushMatrix();
+				GL11.glTranslated(x, y, 0);
+				if(large)
+					GL11.glScaled(1.5, 1.5, 1.5);
+				else
+					GL11.glScaled(0.75, 0.75, 0.75);
+				
+				DiffuseLighting.enable();
+				mc.textRenderer.draw(matrixStack, entityType.getName(), 0,0,Color.WHITE.getRGB());
+				DiffuseLighting.disable();
+				
+				GL11.glPopMatrix();
+				
+				return entityType.getName().getString();
+			}
+		}
+	}
+}

--- a/src/main/java/net/wurstclient/clickgui/screens/EditEntityListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditEntityListScreen.java
@@ -7,7 +7,6 @@
  */
 package net.wurstclient.clickgui.screens;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
@@ -16,17 +15,11 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.render.DiffuseLighting;
-import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.LiteralText;
-import net.minecraft.text.Text;
-import net.minecraft.util.registry.Registry;
-import net.wurstclient.settings.BlockListSetting;
 import net.wurstclient.settings.EntityListSetting;
-import net.wurstclient.util.BlockUtils;
 import net.wurstclient.util.EntityUtils;
 import net.wurstclient.util.ListWidget;
 import org.lwjgl.glfw.GLFW;

--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -74,6 +74,7 @@ public final class HackList implements UpdateListener
 	public final CriticalsHack criticalsHack = new CriticalsHack();
 	public final DerpHack derpHack = new DerpHack();
 	public final DolphinHack dolphinHack = new DolphinHack();
+	public final EntityEspHack entityEspHack = new EntityEspHack();
 	public final ExcavatorHack excavatorHack = new ExcavatorHack();
 	public final ExtraElytraHack extraElytraHack = new ExtraElytraHack();
 	public final FancyChatHack fancyChatHack = new FancyChatHack();

--- a/src/main/java/net/wurstclient/hacks/EntityEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/EntityEspHack.java
@@ -7,9 +7,7 @@
  */
 package net.wurstclient.hacks;
 
-import jdk.nashorn.internal.runtime.logging.Logger;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.passive.PigEntity;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 import net.wurstclient.Category;

--- a/src/main/java/net/wurstclient/hacks/EntityEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/EntityEspHack.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.hacks;
+
+import jdk.nashorn.internal.runtime.logging.Logger;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.PigEntity;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+import net.wurstclient.Category;
+import net.wurstclient.SearchTags;
+import net.wurstclient.events.CameraTransformViewBobbingListener;
+import net.wurstclient.events.RenderListener;
+import net.wurstclient.events.UpdateListener;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
+import net.wurstclient.settings.EntityListSetting;
+import net.wurstclient.settings.EnumSetting;
+import net.wurstclient.util.EntityUtils;
+import net.wurstclient.util.RenderUtils;
+import net.wurstclient.util.RotationUtils;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+@SearchTags({"entity esp", "EntityTracers", "entity tracers"})
+public final class EntityEspHack extends Hack implements UpdateListener,
+	CameraTransformViewBobbingListener, RenderListener
+{
+	private final EnumSetting<Style> style =
+		new EnumSetting<>("Style", Style.values(), Style.BOXES);
+	
+	private final EnumSetting<BoxSize> boxSize = new EnumSetting<>("Box size",
+		"\u00a7lAccurate\u00a7r mode shows the exact\n"
+			+ "hitbox of each entity.\n"
+			+ "\u00a7lFancy\u00a7r mode shows slightly larger\n"
+			+ "boxes that look better.",
+		BoxSize.values(), BoxSize.FANCY);
+	
+	private final EntityListSetting entityListSetting = new EntityListSetting(
+			"Entities",
+			"The entities to show");
+	
+	private final CheckboxSetting filterInvisible = new CheckboxSetting(
+		"Filter invisible", "Won't show invisible entities.", false);
+	
+	private int mobBox;
+	private final ArrayList<Entity> entities = new ArrayList<>();
+	
+	public EntityEspHack()
+	{
+		super("EntityESP", "Highlights nearby entities.");
+		setCategory(Category.RENDER);
+		addSetting(style);
+		addSetting(boxSize);
+		addSetting(entityListSetting);
+		addSetting(filterInvisible);
+	}
+	
+	@Override
+	public String getRenderName() {
+		return "EntityESP (" + entityListSetting.size() + ")";
+	}
+	
+	@Override
+	public void onEnable()
+	{
+		EVENTS.add(UpdateListener.class, this);
+		EVENTS.add(CameraTransformViewBobbingListener.class, this);
+		EVENTS.add(RenderListener.class, this);
+		
+		mobBox = GL11.glGenLists(1);
+		GL11.glNewList(mobBox, GL11.GL_COMPILE);
+		Box bb = new Box(-0.5, 0, -0.5, 0.5, 1, 0.5);
+		RenderUtils.drawOutlinedBox(bb);
+		GL11.glEndList();
+	}
+	
+	@Override
+	public void onDisable()
+	{
+		EVENTS.remove(UpdateListener.class, this);
+		EVENTS.remove(CameraTransformViewBobbingListener.class, this);
+		EVENTS.remove(RenderListener.class, this);
+		
+		GL11.glDeleteLists(mobBox, 1);
+		mobBox = 0;
+	}
+	
+	@Override
+	public void onUpdate()
+	{
+		entities.clear();
+		
+		Stream<Entity> stream =
+			StreamSupport.stream(MC.world.getEntities().spliterator(), false)
+				.filter(e -> Collections.binarySearch(entityListSetting.getEntityNames(),
+						EntityUtils.getEntityName(e.getType())) >= 0)
+				.filter(e -> !e.removed);
+		
+		if(filterInvisible.isChecked())
+			stream = stream.filter(e -> !e.isInvisible());
+		
+		entities.addAll(stream.collect(Collectors.toList()));
+	}
+	
+	@Override
+	public void onCameraTransformViewBobbing(
+		CameraTransformViewBobbingEvent event)
+	{
+		if(style.getSelected().lines)
+			event.cancel();
+	}
+	
+	@Override
+	public void onRender(float partialTicks)
+	{
+		// GL settings
+		GL11.glEnable(GL11.GL_BLEND);
+		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+		GL11.glEnable(GL11.GL_LINE_SMOOTH);
+		GL11.glLineWidth(2);
+		GL11.glDisable(GL11.GL_TEXTURE_2D);
+		GL11.glDisable(GL11.GL_DEPTH_TEST);
+		GL11.glDisable(GL11.GL_LIGHTING);
+		
+		GL11.glPushMatrix();
+		RenderUtils.applyRenderOffset();
+		
+		if(style.getSelected().boxes)
+			renderBoxes(partialTicks);
+		
+		if(style.getSelected().lines)
+			renderTracers(partialTicks);
+		
+		GL11.glPopMatrix();
+		
+		// GL resets
+		GL11.glColor4f(1, 1, 1, 1);
+		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		GL11.glEnable(GL11.GL_TEXTURE_2D);
+		GL11.glDisable(GL11.GL_BLEND);
+		GL11.glDisable(GL11.GL_LINE_SMOOTH);
+	}
+	
+	private void renderBoxes(double partialTicks)
+	{
+		double extraSize = boxSize.getSelected().extraSize;
+		
+		for(Entity e : entities)
+		{
+			GL11.glPushMatrix();
+			
+			GL11.glTranslated(e.prevX + (e.getX() - e.prevX) * partialTicks,
+				e.prevY + (e.getY() - e.prevY) * partialTicks,
+				e.prevZ + (e.getZ() - e.prevZ) * partialTicks);
+			
+			GL11.glScaled(e.getWidth() + extraSize, e.getHeight() + extraSize,
+				e.getWidth() + extraSize);
+			
+			float f = MC.player.distanceTo(e) / 20F;
+			GL11.glColor4f(2 - f, f, 0, 0.5F);
+			
+			GL11.glCallList(mobBox);
+			
+			GL11.glPopMatrix();
+		}
+	}
+	
+	private void renderTracers(double partialTicks)
+	{
+		Vec3d start =
+			RotationUtils.getClientLookVec().add(RenderUtils.getCameraPos());
+		
+		GL11.glBegin(GL11.GL_LINES);
+		for(Entity e : entities)
+		{
+			Vec3d end = e.getBoundingBox().getCenter()
+				.subtract(new Vec3d(e.getX(), e.getY(), e.getZ())
+					.subtract(e.prevX, e.prevY, e.prevZ)
+					.multiply(1 - partialTicks));
+			
+			float f = MC.player.distanceTo(e) / 20F;
+			GL11.glColor4f(2 - f, f, 0, 0.5F);
+			
+			GL11.glVertex3d(start.x, start.y, start.z);
+			GL11.glVertex3d(end.x, end.y, end.z);
+		}
+		GL11.glEnd();
+	}
+	
+	private enum Style
+	{
+		BOXES("Boxes only", true, false),
+		LINES("Lines only", false, true),
+		LINES_AND_BOXES("Lines and boxes", true, true);
+		
+		private final String name;
+		private final boolean boxes;
+		private final boolean lines;
+		
+		private Style(String name, boolean boxes, boolean lines)
+		{
+			this.name = name;
+			this.boxes = boxes;
+			this.lines = lines;
+		}
+		
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+	
+	private enum BoxSize
+	{
+		ACCURATE("Accurate", 0),
+		FANCY("Fancy", 0.1);
+		
+		private final String name;
+		private final double extraSize;
+		
+		private BoxSize(String name, double extraSize)
+		{
+			this.name = name;
+			this.extraSize = extraSize;
+		}
+		
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+}

--- a/src/main/java/net/wurstclient/settings/EntityListSetting.java
+++ b/src/main/java/net/wurstclient/settings/EntityListSetting.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.settings;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import net.wurstclient.WurstClient;
+import net.wurstclient.clickgui.Component;
+import net.wurstclient.clickgui.components.BlockListEditButton;
+import net.wurstclient.clickgui.components.EntityListEditButton;
+import net.wurstclient.keybinds.PossibleKeybind;
+import net.wurstclient.util.BlockUtils;
+import net.wurstclient.util.EntityUtils;
+import net.wurstclient.util.json.JsonException;
+import net.wurstclient.util.json.JsonUtils;
+import net.wurstclient.util.json.WsonArray;
+
+import java.util.*;
+
+public final class EntityListSetting extends Setting
+{
+	private final ArrayList<String> entityNames = new ArrayList<>();
+	private final String[] defaultNames;
+	
+	public EntityListSetting(String name, String description, String... entities)
+	{
+		super(name, description);
+		
+		Arrays.stream(entities).parallel()
+				.map(EntityUtils::getEntityTypeFromName)
+				.filter(Objects::nonNull).map(EntityUtils::getEntityName).distinct()
+				.sorted().forEachOrdered(entityNames::add);
+		defaultNames = entityNames.toArray(new String[0]);
+	}
+	
+	public List<String> getEntityNames()
+	{
+		return Collections.unmodifiableList(entityNames);
+	}
+	
+	public void add(EntityType<?> entityType)
+	{
+		
+		if (entityType == null)
+			return;
+		
+		String name = EntityUtils.getEntityName(entityType);
+		if(Collections.binarySearch(entityNames, name) >= 0)
+			return;
+		
+		entityNames.add(name);
+		Collections.sort(entityNames);
+		WurstClient.INSTANCE.saveSettings();
+	}
+	
+	public void remove(int index)
+	{
+		if(index < 0 || index >= entityNames.size())
+			return;
+		
+		entityNames.remove(index);
+		WurstClient.INSTANCE.saveSettings();
+	}
+	
+	public int size() {
+		return this.entityNames.size();
+	}
+	
+	public void resetToDefaults()
+	{
+		entityNames.clear();
+		entityNames.addAll(Arrays.asList(defaultNames));
+		WurstClient.INSTANCE.saveSettings();
+	}
+	
+	@Override
+	public Component getComponent()
+	{
+		return new EntityListEditButton(this);
+	}
+	
+	@Override
+	public void fromJson(JsonElement json)
+	{
+		try
+		{
+			WsonArray wson = JsonUtils.getAsArray(json);
+			entityNames.clear();
+			
+			wson.getAllStrings().parallelStream()
+				.map(EntityUtils::getEntityTypeFromName)
+				.filter(Objects::nonNull).map(EntityUtils::getEntityName).distinct()
+				.sorted().forEachOrdered(entityNames::add);
+			
+		}catch(JsonException e)
+		{
+			e.printStackTrace();
+			resetToDefaults();
+		}
+	}
+	
+	@Override
+	public JsonElement toJson()
+	{
+		JsonArray json = new JsonArray();
+		entityNames.forEach(json::add);
+		return json;
+	}
+	
+	@Override
+	public Set<PossibleKeybind> getPossibleKeybinds(String featureName)
+	{
+		return new LinkedHashSet<>();
+	}
+}

--- a/src/main/java/net/wurstclient/settings/EntityListSetting.java
+++ b/src/main/java/net/wurstclient/settings/EntityListSetting.java
@@ -9,17 +9,11 @@ package net.wurstclient.settings;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import net.minecraft.block.Block;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import net.wurstclient.WurstClient;
 import net.wurstclient.clickgui.Component;
-import net.wurstclient.clickgui.components.BlockListEditButton;
 import net.wurstclient.clickgui.components.EntityListEditButton;
 import net.wurstclient.keybinds.PossibleKeybind;
-import net.wurstclient.util.BlockUtils;
 import net.wurstclient.util.EntityUtils;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;

--- a/src/main/java/net/wurstclient/util/EntityUtils.java
+++ b/src/main/java/net/wurstclient/util/EntityUtils.java
@@ -12,8 +12,6 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
 import net.minecraft.util.registry.Registry;
 
-import java.util.Optional;
-
 public enum EntityUtils
 {
 	;

--- a/src/main/java/net/wurstclient/util/EntityUtils.java
+++ b/src/main/java/net/wurstclient/util/EntityUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014 - 2020 | Alexander01998 | All rights reserved.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.InvalidIdentifierException;
+import net.minecraft.util.registry.Registry;
+
+import java.util.Optional;
+
+public enum EntityUtils
+{
+	;
+	
+	public static EntityType<?> getEntityTypeFromName(String name)
+	{
+		try
+		{
+			return Registry.ENTITY_TYPE.getOrEmpty(new Identifier(name)).orElse(null);
+			
+		}catch(InvalidIdentifierException e)
+		{
+			return null;
+		}
+	}
+	
+	public static String getEntityName(EntityType<?> entityType)
+	{
+		return Registry.ENTITY_TYPE.getId(entityType).toString();
+	}
+	
+}


### PR DESCRIPTION
## Description
This hack functions similarly to MobESP, with the difference being that instead of checking if entities are a `instanceof MobEntity`, we instead let the user provide a list of entities which then are used when comparing the entities.
This not only lets us find specific mods such as zombie villagers, but also allows us to highlight entities such as arrows and minecarts.

To achieve this, I've also added a new setting type to allow for selecting a list of entities. Also added a new `EntityUtil` class that currently just provides easier methods for getting `EntityType<?>` from names and vice-versa.