### PR TITLE
Fixed ChestESP on 20w45a fixes #206

### DIFF
--- a/src/main/java/net/wurstclient/hacks/ChestEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ChestEspHack.java
@@ -8,23 +8,32 @@
 package net.wurstclient.hacks;
 
 import java.util.ArrayList;
-
-import org.lwjgl.opengl.GL11;
-
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ChestBlock;
+import net.minecraft.block.entity.BarrelBlockEntity;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.ChestBlockEntity;
+import net.minecraft.block.entity.EnderChestBlockEntity;
+import net.minecraft.block.entity.ShulkerBoxBlockEntity;
+import net.minecraft.block.entity.TrappedChestBlockEntity;
+import net.minecraft.block.enums.ChestType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.vehicle.ChestMinecartEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.chunk.BlockEntityTickInvoker;
 import net.wurstclient.Category;
 import net.wurstclient.events.CameraTransformViewBobbingListener;
 import net.wurstclient.events.RenderListener;
 import net.wurstclient.events.UpdateListener;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.mixinterface.IWorld;
 import net.wurstclient.settings.EnumSetting;
-import net.wurstclient.util.ChatUtils;
+import net.wurstclient.util.BlockUtils;
 import net.wurstclient.util.RenderUtils;
 import net.wurstclient.util.RotationUtils;
+import org.lwjgl.opengl.GL11;
 
 public class ChestEspHack extends Hack implements UpdateListener,
 	CameraTransformViewBobbingListener, RenderListener
@@ -58,16 +67,12 @@ public class ChestEspHack extends Hack implements UpdateListener,
 	}
 	
 	@Override
-	protected void onEnable()
-	{
+	protected void onEnable() {
 		EVENTS.add(UpdateListener.class, this);
 		EVENTS.add(CameraTransformViewBobbingListener.class, this);
 		EVENTS.add(RenderListener.class, this);
-		
+
 		setupDisplayLists();
-		
-		ChatUtils.error("Sorry, ChestESP is currently broken.");
-		setEnabled(false);
 	}
 	
 	private void setupDisplayLists()
@@ -129,110 +134,120 @@ public class ChestEspHack extends Hack implements UpdateListener,
 	}
 	
 	@Override
-	public void onUpdate()
-	{
+	public void onUpdate() {
 		basicChests.clear();
 		trappedChests.clear();
 		enderChests.clear();
 		shulkerBoxes.clear();
-		
-		// for(BlockEntity blockEntity : MC.world.blockEntities)
-		// if(blockEntity instanceof TrappedChestBlockEntity)
-		// {
-		// Box box = getBoxFromChest((ChestBlockEntity)blockEntity);
-		//
-		// if(box != null)
-		// trappedChests.add(box);
-		//
-		// }else if(blockEntity instanceof ChestBlockEntity)
-		// {
-		// Box box = getBoxFromChest((ChestBlockEntity)blockEntity);
-		//
-		// if(box != null)
-		// basicChests.add(box);
-		//
-		// }else if(blockEntity instanceof EnderChestBlockEntity)
-		// {
-		// BlockPos pos = blockEntity.getPos();
-		// if(!BlockUtils.canBeClicked(pos))
-		// continue;
-		//
-		// Box bb = BlockUtils.getBoundingBox(pos);
-		// enderChests.add(bb);
-		//
-		// }else if(blockEntity instanceof ShulkerBoxBlockEntity)
-		// {
-		// BlockPos pos = blockEntity.getPos();
-		// if(!BlockUtils.canBeClicked(pos))
-		// continue;
-		//
-		// Box bb = BlockUtils.getBoundingBox(pos);
-		// shulkerBoxes.add(bb);
-		//
-		// }else if(blockEntity instanceof BarrelBlockEntity)
-		// {
-		// BlockPos pos = blockEntity.getPos();
-		// if(!BlockUtils.canBeClicked(pos))
-		// continue;
-		//
-		// Box bb = BlockUtils.getBoundingBox(pos);
-		// basicChests.add(bb);
-		// }
-		
+
+		for (BlockEntityTickInvoker blockEntityTicker : ((IWorld) MC.world).getBlockEntities()) {
+			BlockEntity blockEntity = MC.world.getBlockEntity(blockEntityTicker.getPos());
+
+			if (blockEntity instanceof TrappedChestBlockEntity) {
+				Box box = getBoxFromChest((ChestBlockEntity) blockEntity);
+				if (box != null) {
+					trappedChests.add(box);
+				}
+			}
+			if (blockEntity instanceof TrappedChestBlockEntity) {
+				Box box = getBoxFromChest((ChestBlockEntity) blockEntity);
+
+				if (box != null) {
+					trappedChests.add(box);
+				}
+
+			} else if (blockEntity instanceof ChestBlockEntity) {
+				Box box = getBoxFromChest((ChestBlockEntity) blockEntity);
+
+				if (box != null) {
+					basicChests.add(box);
+				}
+
+			} else if (blockEntity instanceof EnderChestBlockEntity) {
+				BlockPos pos = blockEntity.getPos();
+				if (!BlockUtils.canBeClicked(pos)) {
+					continue;
+				}
+
+				Box bb = BlockUtils.getBoundingBox(pos);
+				enderChests.add(bb);
+
+			} else if (blockEntity instanceof ShulkerBoxBlockEntity) {
+				BlockPos pos = blockEntity.getPos();
+				if (!BlockUtils.canBeClicked(pos)) {
+					continue;
+				}
+
+				Box bb = BlockUtils.getBoundingBox(pos);
+				shulkerBoxes.add(bb);
+
+			} else if (blockEntity instanceof BarrelBlockEntity) {
+				BlockPos pos = blockEntity.getPos();
+				if (!BlockUtils.canBeClicked(pos)) {
+					continue;
+				}
+
+				Box bb = BlockUtils.getBoundingBox(pos);
+				basicChests.add(bb);
+			}
+		}
+
 		GL11.glNewList(normalChests, GL11.GL_COMPILE);
 		renderBoxes(basicChests, greenBox);
 		renderBoxes(trappedChests, orangeBox);
 		renderBoxes(enderChests, cyanBox);
 		renderBoxes(shulkerBoxes, purpleBox);
 		GL11.glEndList();
-		
+
 		minecarts.clear();
-		for(Entity entity : MC.world.getEntities())
-			if(entity instanceof ChestMinecartEntity)
+		for (Entity entity : MC.world.getEntities()) {
+			if (entity instanceof ChestMinecartEntity) {
 				minecarts.add(entity);
+			}
+		}
 	}
-	
-	// private Box getBoxFromChest(ChestBlockEntity chestBE)
-	// {
-	// BlockState state = chestBE.getCachedState();
-	// if(!state.contains(ChestBlock.CHEST_TYPE))
-	// return null;
-	//
-	// ChestType chestType = state.get(ChestBlock.CHEST_TYPE);
-	//
-	// // ignore other block in double chest
-	// if(chestType == ChestType.LEFT)
-	// return null;
-	//
-	// BlockPos pos = chestBE.getPos();
-	// if(!BlockUtils.canBeClicked(pos))
-	// return null;
-	//
-	// Box box = BlockUtils.getBoundingBox(pos);
-	//
-	// // larger box for double chest
-	// if(chestType != ChestType.SINGLE)
-	// {
-	// BlockPos pos2 = pos.offset(ChestBlock.getFacing(state));
-	//
-	// if(BlockUtils.canBeClicked(pos2))
-	// {
-	// Box box2 = BlockUtils.getBoundingBox(pos2);
-	// box = box.union(box2);
-	// }
-	// }
-	//
-	// return box;
-	// }
-	
+
+	private Box getBoxFromChest(ChestBlockEntity chestBE) {
+		BlockState state = chestBE.getCachedState();
+		if (!state.contains(ChestBlock.CHEST_TYPE)) {
+			return null;
+		}
+
+		ChestType chestType = state.get(ChestBlock.CHEST_TYPE);
+
+		// ignore other block in double chest
+		if (chestType == ChestType.LEFT) {
+			return null;
+		}
+
+		BlockPos pos = chestBE.getPos();
+		if (!BlockUtils.canBeClicked(pos)) {
+			return null;
+		}
+
+		Box box = BlockUtils.getBoundingBox(pos);
+
+		// larger box for double chest
+		if (chestType != ChestType.SINGLE) {
+			BlockPos pos2 = pos.offset(ChestBlock.getFacing(state));
+
+			if (BlockUtils.canBeClicked(pos2)) {
+				Box box2 = BlockUtils.getBoundingBox(pos2);
+				box = box.union(box2);
+			}
+		}
+
+		return box;
+	}
+
 	@Override
 	public void onCameraTransformViewBobbing(
-		CameraTransformViewBobbingEvent event)
-	{
-		if(style.getSelected().lines)
+		CameraTransformViewBobbingEvent event) {
+		if (style.getSelected().lines) {
 			event.cancel();
+		}
 	}
-	
+
 	@Override
 	public void onRender(float partialTicks)
 	{

--- a/src/main/java/net/wurstclient/mixin/WorldMixin.java
+++ b/src/main/java/net/wurstclient/mixin/WorldMixin.java
@@ -7,7 +7,12 @@
  */
 package net.wurstclient.mixin;
 
+import java.util.List;
+import net.minecraft.world.chunk.BlockEntityTickInvoker;
+import net.wurstclient.mixinterface.IWorld;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -18,8 +23,11 @@ import net.wurstclient.WurstClient;
 import net.wurstclient.hacks.NoWeatherHack;
 
 @Mixin(World.class)
-public abstract class WorldMixin implements WorldAccess, AutoCloseable
+public abstract class WorldMixin implements WorldAccess, AutoCloseable, IWorld
 {
+
+	@Shadow @Final protected List<BlockEntityTickInvoker> blockEntityTickers;
+
 	@Inject(at = {@At("HEAD")},
 		method = {"getRainGradient(F)F"},
 		cancellable = true)
@@ -53,5 +61,10 @@ public abstract class WorldMixin implements WorldAccess, AutoCloseable
 			return noWeatherHack.getChangedMoonPhase();
 		
 		return getDimension().getMoonPhase(getLunarTime());
+	}
+
+	@Override
+	public List<BlockEntityTickInvoker> getBlockEntities() {
+		return blockEntityTickers;
 	}
 }

--- a/src/main/java/net/wurstclient/mixinterface/IWorld.java
+++ b/src/main/java/net/wurstclient/mixinterface/IWorld.java
@@ -1,0 +1,15 @@
+package net.wurstclient.mixinterface;
+
+import java.util.List;
+import net.minecraft.world.chunk.BlockEntityTickInvoker;
+
+/**
+ * IWorld
+ *
+ * @author Hexeption admin@hexeption.co.uk
+ * @since 10/11/2020 - 04:38 am
+ */
+public interface IWorld {
+
+    List<BlockEntityTickInvoker> getBlockEntities();
+}


### PR DESCRIPTION
## Description
Fixed ChestESP using `blockEntityTickers` in world needed to use a Mixin to get the protected field.

## (Optional) screenshots / videos
![R3XMs9S3Ho](https://user-images.githubusercontent.com/4052647/98629374-9ae3c780-2310-11eb-801b-2aeb796d7f05.png)
