### PR TITLE
FeedAura baby filter

### DIFF
--- a/src/main/java/net/wurstclient/hacks/FeedAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/FeedAuraHack.java
@@ -12,6 +12,8 @@ import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import net.minecraft.entity.passive.PassiveEntity;
+import net.wurstclient.settings.CheckboxSetting;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -55,6 +57,10 @@ public final class FeedAuraHack extends Hack
 			+ "the least head movement.\n"
 			+ "\u00a7lHealth\u00a7r - Feeds the weakest animal.",
 		Priority.values(), Priority.ANGLE);
+
+	private final CheckboxSetting filterBabies =
+			new CheckboxSetting("Filter babies",
+					"Won't feed baby mobs.\nThis saves food, but slows baby growth.", false);
 	
 	private AnimalEntity target;
 	private AnimalEntity renderTarget;
@@ -65,6 +71,7 @@ public final class FeedAuraHack extends Hack
 		setCategory(Category.OTHER);
 		addSetting(range);
 		addSetting(priority);
+		addSetting(filterBabies);
 	}
 	
 	@Override
@@ -107,7 +114,10 @@ public final class FeedAuraHack extends Hack
 			.filter(e -> !e.removed).filter(e -> e instanceof AnimalEntity)
 			.map(e -> (AnimalEntity)e).filter(e -> e.getHealth() > 0)
 			.filter(e -> player.squaredDistanceTo(e) <= rangeSq)
-			.filter(e -> e.isBreedingItem(heldStack)).filter(e -> e.canEat());
+			.filter(e -> e.isBreedingItem(heldStack)).filter(AnimalEntity::canEat);
+
+		if (filterBabies.isChecked())
+			stream = stream.filter(e -> !(e != null && e.isBaby()));
 		
 		target = stream.min(priority.getSelected().comparator).orElse(null);
 		renderTarget = target;

--- a/src/main/java/net/wurstclient/hacks/FeedAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/FeedAuraHack.java
@@ -117,7 +117,7 @@ public final class FeedAuraHack extends Hack
 			.filter(e -> e.isBreedingItem(heldStack)).filter(AnimalEntity::canEat);
 
 		if (filterBabies.isChecked())
-			stream = stream.filter(e -> !(e != null && e.isBaby()));
+			stream = stream.filter(e -> !e.isBaby());
 		
 		target = stream.min(priority.getSelected().comparator).orElse(null);
 		renderTarget = target;


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)
The default FeedAura automatically feeds any mobs that can be fed with the item held in hand. This includes babies. Feeding babies will cause them to grow faster, but at the expense of more food. Adding an option to filter out babies means that a user can choose to save food by not feeding babies and letting them grow by themselves.

## (Optional) screenshots / videos
If applicable, add screenshots or videos to help explain your pull request.
