### PR TITLE
Created Spammer with Character Remapping

### DIFF
--- a/src/main/java/net/wurstclient/command/CmdList.java
+++ b/src/main/java/net/wurstclient/command/CmdList.java
@@ -63,6 +63,7 @@ public final class CmdList
 	public final UnbindCmd unbindCmd = new UnbindCmd();
 	public final VClipCmd vClipCmd = new VClipCmd();
 	public final ViewNbtCmd viewNbtCmd = new ViewNbtCmd();
+	public final SpamCmd spamCmd = new SpamCmd();
 	
 	private final TreeMap<String, Command> cmds =
 		new TreeMap<>((o1, o2) -> o1.compareToIgnoreCase(o2));

--- a/src/main/java/net/wurstclient/command/CmdProcessor.java
+++ b/src/main/java/net/wurstclient/command/CmdProcessor.java
@@ -8,7 +8,9 @@
 package net.wurstclient.command;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
+import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
 import net.minecraft.util.crash.CrashException;
 import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
@@ -17,113 +19,95 @@ import net.wurstclient.events.ChatOutputListener;
 import net.wurstclient.hacks.TooManyHaxHack;
 import net.wurstclient.util.ChatUtils;
 
-public final class CmdProcessor implements ChatOutputListener
-{
+public final class CmdProcessor implements ChatOutputListener {
 	private final CmdList cmds;
-	
-	public CmdProcessor(CmdList cmds)
-	{
+
+	public CmdProcessor(CmdList cmds) {
 		this.cmds = cmds;
 	}
-	
+
 	@Override
-	public void onSentMessage(ChatOutputEvent event)
-	{
-		if(!WurstClient.INSTANCE.isEnabled())
+	public void onSentMessage(ChatOutputEvent event) {
+		if (!WurstClient.INSTANCE.isEnabled())
 			return;
-		
+
 		String message = event.getOriginalMessage().trim();
-		if(!message.startsWith("."))
+		if (!message.startsWith("."))
 			return;
-		
+
 		event.cancel();
 		process(message.substring(1));
 	}
-	
-	public void process(String input)
-	{
-		try
-		{
+
+	public void process(String input) {
+		try {
 			Command cmd = parseCmd(input);
-			
-			TooManyHaxHack tooManyHax =
-				WurstClient.INSTANCE.getHax().tooManyHaxHack;
-			if(tooManyHax.isEnabled() && tooManyHax.isBlocked(cmd))
-			{
+
+			TooManyHaxHack tooManyHax = WurstClient.INSTANCE.getHax().tooManyHaxHack;
+			if (tooManyHax.isEnabled() && tooManyHax.isBlocked(cmd)) {
 				ChatUtils.error(cmd.getName() + " is blocked by TooManyHax.");
 				return;
 			}
-			
+
 			runCmd(cmd, input);
-			
-		}catch(CmdNotFoundException e)
-		{
+
+		} catch (CmdNotFoundException e) {
 			e.printToChat();
 		}
 	}
-	
-	private Command parseCmd(String input) throws CmdNotFoundException
-	{
+
+	private Command parseCmd(String input) throws CmdNotFoundException {
 		String cmdName = input.split(" ")[0];
 		Command cmd = cmds.getCmdByName(cmdName);
-		
-		if(cmd == null)
+
+		if (cmd == null)
 			throw new CmdNotFoundException(input);
-		
+
 		return cmd;
 	}
-	
-	private void runCmd(Command cmd, String input)
-	{
+
+	private void runCmd(Command cmd, String input) {
 		String[] args = input.split(" ");
 		args = Arrays.copyOfRange(args, 1, args.length);
-		
-		try
-		{
+
+		try {
 			cmd.call(args);
-			
-		}catch(CmdException e)
-		{
+
+		} catch (CmdException e) {
 			e.printToChat(cmd);
-			
-		}catch(Throwable e)
-		{
+
+		} catch (Throwable e) {
 			CrashReport report = CrashReport.create(e, "Running Wurst command");
 			CrashReportSection section = report.addElement("Affected command");
 			section.add("Command input", () -> input);
 			throw new CrashException(report);
 		}
 	}
-	
-	private static class CmdNotFoundException extends Exception
-	{
+
+	private static class CmdNotFoundException extends Exception {
 		private final String input;
-		
-		public CmdNotFoundException(String input)
-		{
+
+		public CmdNotFoundException(String input) {
 			super();
 			this.input = input;
 		}
-		
-		public void printToChat()
-		{
+
+		public void printToChat() {
 			String cmdName = input.split(" ")[0];
 			ChatUtils.error("Unknown command: ." + cmdName);
-			
+
 			StringBuilder helpMsg = new StringBuilder();
-			
-			if(input.startsWith("/"))
-			{
+
+			if (input.startsWith("/")) {
 				helpMsg.append("Use \".say " + input + "\"");
 				helpMsg.append(" to send it as a chat command.");
-				
-			}else
-			{
+
+			} else {
 				helpMsg.append("Type \".help\" for a list of commands or ");
 				helpMsg.append("\".say ." + input + "\"");
 				helpMsg.append(" to send it as a chat message.");
 			}
-			
+
 			ChatUtils.message(helpMsg.toString());
 		}
 	}

--- a/src/main/java/net/wurstclient/command/CmdProcessor.java
+++ b/src/main/java/net/wurstclient/command/CmdProcessor.java
@@ -8,9 +8,7 @@
 package net.wurstclient.command;
 
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
-import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
 import net.minecraft.util.crash.CrashException;
 import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
@@ -19,95 +17,113 @@ import net.wurstclient.events.ChatOutputListener;
 import net.wurstclient.hacks.TooManyHaxHack;
 import net.wurstclient.util.ChatUtils;
 
-public final class CmdProcessor implements ChatOutputListener {
+public final class CmdProcessor implements ChatOutputListener
+{
 	private final CmdList cmds;
-
-	public CmdProcessor(CmdList cmds) {
+	
+	public CmdProcessor(CmdList cmds)
+	{
 		this.cmds = cmds;
 	}
-
+	
 	@Override
-	public void onSentMessage(ChatOutputEvent event) {
-		if (!WurstClient.INSTANCE.isEnabled())
+	public void onSentMessage(ChatOutputEvent event)
+	{
+		if(!WurstClient.INSTANCE.isEnabled())
 			return;
-
+		
 		String message = event.getOriginalMessage().trim();
-		if (!message.startsWith("."))
+		if(!message.startsWith("."))
 			return;
-
+		
 		event.cancel();
 		process(message.substring(1));
 	}
-
-	public void process(String input) {
-		try {
+	
+	public void process(String input)
+	{
+		try
+		{
 			Command cmd = parseCmd(input);
-
-			TooManyHaxHack tooManyHax = WurstClient.INSTANCE.getHax().tooManyHaxHack;
-			if (tooManyHax.isEnabled() && tooManyHax.isBlocked(cmd)) {
+			
+			TooManyHaxHack tooManyHax =
+				WurstClient.INSTANCE.getHax().tooManyHaxHack;
+			if(tooManyHax.isEnabled() && tooManyHax.isBlocked(cmd))
+			{
 				ChatUtils.error(cmd.getName() + " is blocked by TooManyHax.");
 				return;
 			}
-
+			
 			runCmd(cmd, input);
-
-		} catch (CmdNotFoundException e) {
+			
+		}catch(CmdNotFoundException e)
+		{
 			e.printToChat();
 		}
 	}
-
-	private Command parseCmd(String input) throws CmdNotFoundException {
+	
+	private Command parseCmd(String input) throws CmdNotFoundException
+	{
 		String cmdName = input.split(" ")[0];
 		Command cmd = cmds.getCmdByName(cmdName);
-
-		if (cmd == null)
+		
+		if(cmd == null)
 			throw new CmdNotFoundException(input);
-
+		
 		return cmd;
 	}
-
-	private void runCmd(Command cmd, String input) {
+	
+	private void runCmd(Command cmd, String input)
+	{
 		String[] args = input.split(" ");
 		args = Arrays.copyOfRange(args, 1, args.length);
-
-		try {
+		
+		try
+		{
 			cmd.call(args);
-
-		} catch (CmdException e) {
+			
+		}catch(CmdException e)
+		{
 			e.printToChat(cmd);
-
-		} catch (Throwable e) {
+			
+		}catch(Throwable e)
+		{
 			CrashReport report = CrashReport.create(e, "Running Wurst command");
 			CrashReportSection section = report.addElement("Affected command");
 			section.add("Command input", () -> input);
 			throw new CrashException(report);
 		}
 	}
-
-	private static class CmdNotFoundException extends Exception {
+	
+	private static class CmdNotFoundException extends Exception
+	{
 		private final String input;
-
-		public CmdNotFoundException(String input) {
+		
+		public CmdNotFoundException(String input)
+		{
 			super();
 			this.input = input;
 		}
-
-		public void printToChat() {
+		
+		public void printToChat()
+		{
 			String cmdName = input.split(" ")[0];
 			ChatUtils.error("Unknown command: ." + cmdName);
-
+			
 			StringBuilder helpMsg = new StringBuilder();
-
-			if (input.startsWith("/")) {
+			
+			if(input.startsWith("/"))
+			{
 				helpMsg.append("Use \".say " + input + "\"");
 				helpMsg.append(" to send it as a chat command.");
-
-			} else {
+				
+			}else
+			{
 				helpMsg.append("Type \".help\" for a list of commands or ");
 				helpMsg.append("\".say ." + input + "\"");
 				helpMsg.append(" to send it as a chat message.");
 			}
-
+			
 			ChatUtils.message(helpMsg.toString());
 		}
 	}

--- a/src/main/java/net/wurstclient/command/Command.java
+++ b/src/main/java/net/wurstclient/command/Command.java
@@ -31,7 +31,7 @@ public abstract class Command extends Feature
 		this.syntax = syntax;
 	}
 	
-	public abstract void call(String[] args) throws CmdException;
+	public abstract void call(String[] args) throws CmdException, Exception;
 	
 	@Override
 	public final String getName()

--- a/src/main/java/net/wurstclient/commands/SpamCmd.java
+++ b/src/main/java/net/wurstclient/commands/SpamCmd.java
@@ -20,13 +20,13 @@ public final class SpamCmd extends Command {
 	public SpamCmd() {
 		super("spam",
 				"Spams the given chat message while adding randomized charachters."
-						+ "Use the Pipe Symbol (|) to represent spaces in the argument <message>."
 						+ "<length> represents the times <message> is to be spammed."
 						+ "<delay> represents the time between <message> sending in milliseconds."
-						+ "<message> represents the message you want to send."
+						+ "<replace> represents the amount of characters replaced in <message>. Format as a percentage with 2 numbers."
+						+ "<message> represents the message you want to send. <message> can have spaces in it."
 						+ "The following charachters are mapped for replacement:"
 						+ "ÃΒÇÐËfĜĤÌĴĶĹmŃÔpqŘŚŢÙΛŴ×ÝŽäΒçđêFğĥïĵķĺMńöPQŕŚ†üνŵXỳž",
-				".spam <length> <delay> <message>");
+				".spam <length> <delay> <replace> <message>");
 	}
 
 	static Map<String, String> map = new HashMap<String, String>();
@@ -96,13 +96,26 @@ public final class SpamCmd extends Command {
 
 		// Warning for less than 3 arguments
 
-		if (args.length < 3)
-			throw new CmdSyntaxError("There should be 3 Arguments - Do .help spam for more info");
+		if (args.length < 4)
+			throw new CmdSyntaxError("There should be 4 Arguments - Do .help spam for more info");
 
 		// Warning for more than 3 arguments
-
-		if (args.length > 3)
-			throw new CmdSyntaxError("Use the Pipe Symbol (|) to represent spaces - Do .help spam for more info");
+		
+		String toChange1 = "";
+		
+		// Convert all arguments after the first 3 arguments into 1 string for conversion.
+		
+		if (args.length > 3) {
+			StringBuilder message = new StringBuilder();
+			
+			// Combine all arguments after i (3)
+			
+			for (int i = 3; i < args.length; i++) {
+				message.append(" ").append(args[i]);
+			}
+			
+			toChange1 = message.toString();
+		}
 
 		// Warning for incorrect input of Length
 
@@ -113,23 +126,41 @@ public final class SpamCmd extends Command {
 
 		if (!isInteger(args[1]))
 			throw new CmdSyntaxError("Second Argument is Delay - Should be an Intiger");
-
+		
+		// Remove percent sign from chanceInputString1.
+		
+		String chanceInputString1 = args[2];
+		
+		if (chanceInputString1.contains("%")) {
+			chanceInputString1 = chanceInputString1.replace("%", "");
+		}
+		
+		if (!(chanceInputString1.length() == 2))
+			throw new CmdSyntaxError("Use two numbers to represent your Chance - 00 to 99 Supported.");
+		// Warning for incorrect input of Chance
+		
+		if (!isInteger(chanceInputString1))
+			throw new CmdSyntaxError("Third Argument is Chance - Should be an Intiger");
+		
+		// Convert chanceInputString1 to chanceInputString if requirements met.
+		
+		String chanceInputString = chanceInputString1;
+		
+		// Make ChanceInputString into an int
+		
+		int chanceInput = Integer.parseInt(chanceInputString);
+		
+		// Make compatible with Math.Random()
+		
+		double chance = ((double) chanceInput) / 100;
+		
 		// Apply repeatLength and repeatDelay from args input
 
 		int repeatLenght = Integer.parseInt(args[0]);
 		int repeatDelay = Integer.parseInt(args[1]);
-		String toChange1 = args[2];
-		String toChange2 = "";
-
-		// Replace pipe symbol (|) to space symbol ( )
-
-		if (toChange1.contains("|")) {
-			toChange2 = toChange1.replace("|", " ");
-		} else {
-			toChange2 = toChange1;
-		}
-		String toChange = toChange2;
-
+		
+		final String toChange = toChange1;
+		
 		// Starts the program in a new tread
 
 		Thread thread = new Thread() {
@@ -151,7 +182,7 @@ public final class SpamCmd extends Command {
 						// Gets a random value and checks if it is below a probability to get a %
 						// chance.
 
-						if ((Math.random() < 0.5)) {
+						if ((Math.random() < chance)) {
 
 							// Set string temp to string temp after a character has gone through the
 							// function findMapping()

--- a/src/main/java/net/wurstclient/commands/SpamCmd.java
+++ b/src/main/java/net/wurstclient/commands/SpamCmd.java
@@ -123,9 +123,11 @@ public final class SpamCmd extends Command {
 
 		// Replace pipe symbol (|) to space symbol ( )
 
-		if (toChange1.contains("|"))
+		if (toChange1.contains("|")) {
 			toChange2 = toChange1.replace("|", " ");
-
+		} else {
+			toChange2 = toChange1;
+		}
 		String toChange = toChange2;
 
 		// Starts the program in a new tread

--- a/src/main/java/net/wurstclient/commands/SpamCmd.java
+++ b/src/main/java/net/wurstclient/commands/SpamCmd.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ * This is test code by Andrew Popov and is not official.
+ * Code is still being writen and is prone to bugs.
+ */
+package net.wurstclient.commands;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
+import net.wurstclient.SearchTags;
+import net.wurstclient.command.CmdException;
+import net.wurstclient.command.CmdSyntaxError;
+import net.wurstclient.command.Command;
+
+@SearchTags({ "spammer", "spam", "text variation", "repeat", "chat" })
+public final class SpamCmd extends Command {
+	public SpamCmd() {
+		super("spam",
+				"Spams the given chat message while adding randomized charachters."
+						+ "Use the Pipe Symbol (|) to represent spaces in the argument <message>."
+						+ "<length> represents the times <message> is to be spammed."
+						+ "<delay> represents the time between <message> sending in milliseconds."
+						+ "<message> represents the message you want to send."
+						+ "The following charachters are mapped for replacement:"
+						+ "ÃΒÇÐËfĜĤÌĴĶĹmŃÔpqŘŚŢÙΛŴ×ÝŽäΒçđêFğĥïĵķĺMńöPQŕŚ†üνŵXỳž",
+				".spam <length> <delay> <message>");
+	}
+
+	static Map<String, String> map = new HashMap<String, String>();
+	{
+		// Mapping for Character Replacement
+		// Upper Case Mapping
+
+		map.put("A", "Ã");
+		map.put("B", "Β");
+		map.put("C", "Ç");
+		map.put("D", "Ð");
+		map.put("E", "Ë");
+		map.put("F", "f");
+		map.put("G", "Ĝ");
+		map.put("H", "Ĥ");
+		map.put("I", "Ì");
+		map.put("J", "Ĵ");
+		map.put("K", "Ķ");
+		map.put("L", "Ĺ");
+		map.put("M", "m");
+		map.put("N", "Ń");
+		map.put("O", "Ô");
+		map.put("P", "p");
+		map.put("Q", "q");
+		map.put("R", "Ř");
+		map.put("S", "Ś");
+		map.put("T", "Ţ");
+		map.put("U", "Ù");
+		map.put("V", "Λ");
+		map.put("W", "Ŵ");
+		map.put("X", "×");
+		map.put("Y", "Ý");
+		map.put("Z", "Ž");
+
+		// Lower Case Mapping
+
+		map.put("a", "ä");
+		map.put("b", "Β");
+		map.put("c", "ç");
+		map.put("d", "đ");
+		map.put("e", "ê");
+		map.put("f", "F");
+		map.put("g", "ğ");
+		map.put("h", "ĥ");
+		map.put("i", "ï");
+		map.put("j", "ĵ");
+		map.put("k", "ķ");
+		map.put("l", "ĺ");
+		map.put("m", "M");
+		map.put("n", "ń");
+		map.put("o", "ö");
+		map.put("p", "P");
+		map.put("q", "Q");
+		map.put("r", "ŕ");
+		map.put("s", "Ś");
+		map.put("t", "†");
+		map.put("u", "ü");
+		map.put("v", "ν");
+		map.put("w", "ŵ");
+		map.put("x", "X");
+		map.put("y", "ỳ");
+		map.put("z", "ž");
+	}
+
+	@Override
+	public void call(String[] args) throws CmdException, Exception {
+
+		// Warning for less than 3 arguments
+
+		if (args.length < 3)
+			throw new CmdSyntaxError("There should be 3 Arguments - Do .help spam for more info");
+
+		// Warning for more than 3 arguments
+
+		if (args.length > 3)
+			throw new CmdSyntaxError("Use the Pipe Symbol (|) to represent spaces - Do .help spam for more info");
+
+		// Warning for incorrect input of Length
+
+		if (!isInteger(args[0]))
+			throw new CmdSyntaxError("First Argument is Length - Should be an Intiger");
+
+		// Warning for incorrect input of Delay
+
+		if (!isInteger(args[1]))
+			throw new CmdSyntaxError("Second Argument is Delay - Should be an Intiger");
+
+		// Apply repeatLength and repeatDelay from args input
+
+		int repeatLenght = Integer.parseInt(args[0]);
+		int repeatDelay = Integer.parseInt(args[1]);
+		String toChange1 = args[2];
+		String toChange2 = "";
+
+		// Replace pipe symbol (|) to space symbol ( )
+
+		if (toChange1.contains("|"))
+			toChange2 = toChange1.replace("|", " ");
+
+		String toChange = toChange2;
+
+		// Starts the program in a new tread
+
+		Thread thread = new Thread() {
+			public void run() {
+				System.out.println("Spam Thread Running");
+
+				// Repeat for how many times as defined in int repeatLength
+
+				for (int j = 0; j < repeatLenght; j++) {
+
+					// Temporarily changes string temp to string toChange for each repetition
+
+					String temp = toChange;
+
+					// Repeats for each character
+
+					for (int i = 0; i < temp.length(); i++) {
+
+						// Gets a random value and checks if it is below a probability to get a %
+						// chance.
+
+						if ((Math.random() < 0.5)) {
+
+							// Set string temp to string temp after a character has gone through the
+							// function findMapping()
+
+							try {
+								temp = temp.replace(temp.charAt(i), findMapping(temp.charAt(i)));
+							} catch (Exception e) {
+								// Do Nothing because above has a 100% probability of happening
+								e.printStackTrace();
+							}
+						}
+					}
+
+					// Sets string message to string temp
+
+					String message = String.join(" ", temp);
+
+					// Prepares a network packet for Minecraft containing string message
+
+					ChatMessageC2SPacket packet = new ChatMessageC2SPacket(message);
+
+					// Sends the packet with the message to the game server
+
+					MC.getNetworkHandler().sendPacket(packet);
+
+					// Delays the loop that repeats the message by an amount specified in int
+					// releatDelay
+
+					try {
+						TimeUnit.MILLISECONDS.sleep(repeatDelay);
+					} catch (InterruptedException e) {
+						// Do Nothing because above has a 100% probability of happening.
+						e.printStackTrace();
+					}
+				}
+			}
+		};
+
+		thread.start();
+
+	}
+
+	// Function findMapping()
+
+	private static char findMapping(char c) throws Exception {
+
+		// Repeats for every set of mappings
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+
+			// Checks if a mapping key matches with the character
+
+			if (entry.getKey().equals(Character.toString(c))) {
+
+				// Returns the value from the mapping for replacement
+
+				return entry.getValue().charAt(0);
+			}
+		}
+
+		// Returns the original character if there is no mapping for the character
+
+		return c;
+	}
+
+	// Function isInteger(), used to see if <length> and <delay> inputs are correct
+	// to see if a string is an integer
+
+	private static boolean isInteger(String s) {
+
+		try {
+			Integer.parseInt(s);
+
+			// Detects if it is not an int
+
+		} catch (NumberFormatException e) {
+			return false;
+
+			// Detects if it is an int
+
+		} catch (NullPointerException e) {
+			return false;
+		}
+		// Only got here if we didn't return false
+		return true;
+	}
+
+}


### PR DESCRIPTION
I have added a new command that acts as a spammer. The command syntax is "**`.spam <length> <delay> <chance> <message>`**". 
`<length>` represents how many times the spammer repeats the message.
`<delay>` represents how long the spammer is to wait between messages being sent.
`<chance>` represents the chance of characters to be remapped in the message.
`<message>` is the message to be remapped and spammed.

The characters that are mapped for replacement are: "**ÃΒÇÐËfĜĤÌĴĶĹmŃÔpqŘŚŢÙΛŴ×ÝŽäΒçđêFğĥïĵķĺMńöPQŕŚ†üνŵXỳž**"

_Characters **used to be** hardcoded to replace 50% of the time if they are mapped._
This has been replaced by the new `<chance>` argument, which can use anything from 00 to 99.

_`<message>` **used** to use the pipe symbol ("|") to indicate a space in the message, **but it no longer does.**_
Instead, all arguments after the chance argument are combined and used as `<message>`.

The command checks to make sure that all arguments are valid and will throw an error that reflects on the issues that the user is having. If the user incorrectly uses the command, the error will help them correct their syntax.

During testing, one bug that has been fixed had appeared, but no others seemed to manifest.