### PR TITLE
Fix Bug in CactusBlockMixin.java

### DIFF
--- a/src/main/java/net/wurstclient/mixin/CactusBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/CactusBlockMixin.java
@@ -26,7 +26,7 @@ import net.wurstclient.events.CactusCollisionShapeListener.CactusCollisionShapeE
 @Mixin(CactusBlock.class)
 public abstract class CactusBlockMixin extends Block
 {
-	private CactusBlockMixin(WurstClient wurst, Settings block$Settings_1)
+	private CactusBlockMixin(Settings block$Settings_1)
 	{
 		super(block$Settings_1);
 	}

--- a/src/main/java/net/wurstclient/mixin/CactusBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/CactusBlockMixin.java
@@ -33,7 +33,7 @@ public abstract class CactusBlockMixin extends Block
 	
 	@Inject(at = {@At("HEAD")},
 		method = {
-			"getOutlineShape(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/ShapeContext;)Lnet/minecraft/util/shape/VoxelShape;"},
+			"getCollisionShape(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/ShapeContext;)Lnet/minecraft/util/shape/VoxelShape;"},
 		cancellable = true)
 	private void onGetCollisionShape(BlockState blockState_1,
 		BlockView blockView_1, BlockPos blockPos_1,


### PR DESCRIPTION
## Description
The Cactus event for the AntiCactus module didn't work properly because it was injected into the "getOutlineShape" (CactusBlockMixin.java) method but it needs to be injected into the "getCollisionShape", this PR fixes that. Also I removed the unnecessary sausage instance in the constructure of the CactusBlockMixin class.
