### PR TITLE
Fix NoBackground

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ScreenMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.client.gui.AbstractParentElement;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TickableElement;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
 import net.wurstclient.WurstClient;
@@ -46,7 +47,8 @@ public abstract class ScreenMixin extends AbstractParentElement
 		cancellable = true)
 	public void onRenderBackground(MatrixStack matrices, CallbackInfo ci)
 	{
-		if(WurstClient.INSTANCE.getHax().noBackgroundHack.isEnabled())
+		if(WurstClient.INSTANCE.getHax().noBackgroundHack.isEnabled()
+			&& ((Screen)(Object)this) instanceof HandledScreen)
 			ci.cancel();
 	}
 }


### PR DESCRIPTION
NoBackground currently disables the background of any non-inventory GUI, which causes issues with those GUIs.

Example of what a GUI looks like without the fix:
![altmanager](https://user-images.githubusercontent.com/15678918/111080859-dff25300-84d6-11eb-9ff0-85d44bf3c541.PNG)
