### PR TITLE
More Killaura Sliders (fixed)

### DIFF
--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -8,6 +8,7 @@
 package net.wurstclient.hacks;
 
 import java.util.Comparator;
+import java.util.Random;
 import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -62,7 +63,11 @@ public final class KillauraHack extends Hack
 	
 	private final SliderSetting hitDelay = new SliderSetting("Delay",
 			"Delay between hits",
-			0, 1, 20, 0.1, ValueDisplay.DECIMAL);
+			0, 0, 20, 0.1, ValueDisplay.DECIMAL);
+	
+	private final SliderSetting ranDelay = new SliderSetting("Random CPS+",
+			"Range for the random added delay between hits.",
+			1, 0, 3, 0.1, ValueDisplay.DECIMAL);
 	
 	private final EnumSetting<Priority> priority = new EnumSetting<>("Priority",
 		"Determines which entity will be attacked first.\n"

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -136,6 +136,7 @@ public final class KillauraHack extends Hack
 		"Filter end crystals", "Won't attack end crystals.", false);
 	
 
+	private Random rand = new Random();
 	private int timer;
 	private Entity target;
 	private Entity renderTarget;
@@ -146,6 +147,7 @@ public final class KillauraHack extends Hack
 		setCategory(Category.COMBAT);
 		addSetting(range);
 		addSetting(hitDelay);
+		addSetting(ranDelay);
 		addSetting(priority);
 		addSetting(filterPlayers);
 		addSetting(filterSleeping);
@@ -304,7 +306,7 @@ public final class KillauraHack extends Hack
 		player.swingHand(Hand.MAIN_HAND);
 		
 		// start timer
-		timer = hitDelay.getValueI();
+		timer = hitDelay.getValueI() + rand.nextInt(ranDelay.getValueI()+1);
 		target = null;
 	}
 	

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -62,7 +62,7 @@ public final class KillauraHack extends Hack
 	
 	private final SliderSetting hitDelay = new SliderSetting("Delay",
 			"Delay between hits",
-			12, 1, 18, 0.05, ValueDisplay.DECIMAL);
+			0, 1, 20, 0.1, ValueDisplay.DECIMAL);
 	
 	private final EnumSetting<Priority> priority = new EnumSetting<>("Priority",
 		"Determines which entity will be attacked first.\n"
@@ -130,6 +130,8 @@ public final class KillauraHack extends Hack
 	private final CheckboxSetting filterCrystals = new CheckboxSetting(
 		"Filter end crystals", "Won't attack end crystals.", false);
 	
+
+	private int timer;
 	private Entity target;
 	private Entity renderTarget;
 	
@@ -276,11 +278,18 @@ public final class KillauraHack extends Hack
 		
 		WURST.getRotationFaker()
 			.faceVectorPacket(target.getBoundingBox().getCenter());
+		
+		// update timer
+		if(timer > 0) {
+			timer--;
+			return;
+		}
 	}
 	
 	@Override
 	public void onPostMotion()
 	{
+		if (timer > 0) return;
 		if(target == null)
 			return;
 		
@@ -289,6 +298,8 @@ public final class KillauraHack extends Hack
 		MC.interactionManager.attackEntity(player, target);
 		player.swingHand(Hand.MAIN_HAND);
 		
+		// start timer
+		timer = hitDelay.getValueI();
 		target = null;
 	}
 	

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -62,12 +62,16 @@ public final class KillauraHack extends Hack
 		5, 1, 10, 0.05, ValueDisplay.DECIMAL);
 	
 	private final SliderSetting hitDelay = new SliderSetting("Delay",
-			"Delay between hits",
+			"Delay between hits.\n"
+			+ "Set this to 0 for 1.9+ servers.",
 			0, 0, 20, 0.1, ValueDisplay.DECIMAL);
 	
-	private final SliderSetting ranDelay = new SliderSetting("Random CPS+",
-			"Range for the random added delay between hits.",
-			1, 0, 3, 0.1, ValueDisplay.DECIMAL);
+	private final SliderSetting ranDelay = new SliderSetting("CPS Spoofer",
+			"Range for the random added delay between hits.\n"
+			+ "THE DELAY ONLY ADDS NUMBERS!\n"
+			+ "It doesn't subtract randoms, so make sure\n"
+			+ "your non-random delay is your minimum.",
+			0.1, 0, 5, 0.1, ValueDisplay.DECIMAL);
 	
 	private final EnumSetting<Priority> priority = new EnumSetting<>("Priority",
 		"Determines which entity will be attacked first.\n"

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -60,6 +60,10 @@ public final class KillauraHack extends Hack
 			+ "specified value will not be attacked.",
 		5, 1, 10, 0.05, ValueDisplay.DECIMAL);
 	
+	private final SliderSetting hitDelay = new SliderSetting("Delay",
+			"Delay between hits",
+			12, 1, 18, 0.05, ValueDisplay.DECIMAL);
+	
 	private final EnumSetting<Priority> priority = new EnumSetting<>("Priority",
 		"Determines which entity will be attacked first.\n"
 			+ "\u00a7lDistance\u00a7r - Attacks the closest entity.\n"
@@ -134,6 +138,7 @@ public final class KillauraHack extends Hack
 		super("Killaura", "Automatically attacks entities around you.");
 		setCategory(Category.COMBAT);
 		addSetting(range);
+		addSetting(hitDelay);
 		addSetting(priority);
 		addSetting(filterPlayers);
 		addSetting(filterSleeping);

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -59,7 +59,7 @@ public final class KillauraHack extends Hack
 		"Determines how far Killaura will reach\n" + "to attack entities.\n"
 			+ "Anything that is further away than the\n"
 			+ "specified value will not be attacked.",
-		5, 1, 10, 0.05, ValueDisplay.DECIMAL);
+		0, 0, 10, 0.05, ValueDisplay.DECIMAL);
 	
 	private final SliderSetting hitDelay = new SliderSetting("Delay",
 			"Delay between hits.\n"


### PR DESCRIPTION
## Description
I basically re-added the Delay feature from 1.8. It's turned off by default, but pulling the slider up adds tick delays in between your attacks.

The Random CPS feature also comes with this kit, as I've seen a bunch of people on this repo request someone to add it.

The random CPS addition is ONLY ADDITION. It does not subtract values, so make sure your non-random delay slider is set to the absolute minimum delay you want to have.

Fully tested in a 1.16 world, and NOW ALSO TESTED ON 1.8 😁

The only downside is that I haven't added this feature to other variants of KillAura. Only the main one.