### PR TITLE
ItemESP can now mark specific items

### DIFF
--- a/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
@@ -30,167 +30,146 @@ import net.minecraft.util.registry.Registry;
 import net.wurstclient.settings.ItemListSetting;
 import net.wurstclient.util.ListWidget;
 
-public final class EditItemListScreen extends Screen
-{
+public final class EditItemListScreen extends Screen {
 	private final Screen prevScreen;
 	private final ItemListSetting itemList;
-	
+
 	private ListGui listGui;
 	private TextFieldWidget itemNameField;
 	private ButtonWidget addButton;
 	private ButtonWidget removeButton;
 	private ButtonWidget doneButton;
-	
+	private ButtonWidget searchTypeButton;
+
 	private Item itemToAdd;
-	
-	public EditItemListScreen(Screen prevScreen, ItemListSetting itemList)
-	{
+
+	public EditItemListScreen(Screen prevScreen, ItemListSetting itemList) {
 		super(new LiteralText(""));
 		this.prevScreen = prevScreen;
 		this.itemList = itemList;
 	}
-	
+
 	@Override
-	public boolean isPauseScreen()
-	{
+	public boolean isPauseScreen() {
 		return false;
 	}
-	
+
 	@Override
-	public void init()
-	{
+	public void init() {
 		listGui = new ListGui(client, this, itemList.getItemNames());
-		
-		itemNameField = new TextFieldWidget(client.textRenderer,
-			width / 2 - 152, height - 55, 150, 18, new LiteralText(""));
+
+		itemNameField = new TextFieldWidget(client.textRenderer, width / 2 - 152, height - 55, 150, 18,
+				new LiteralText(""));
 		children.add(itemNameField);
-		
-		addButton(addButton = new ButtonWidget(width / 2 - 2, height - 56, 30,
-			20, new LiteralText("Add"), b -> {
-				itemList.add(itemToAdd);
-				itemNameField.setText("");
-			}));
-		
-		addButton(removeButton = new ButtonWidget(width / 2 + 52, height - 56,
-			100, 20, new LiteralText("Remove Selected"),
-			b -> itemList.remove(listGui.selected)));
-		
-		addButton(new ButtonWidget(width - 108, 8, 100, 20,
-			new LiteralText("Reset to Defaults"),
-			b -> client.openScreen(new ConfirmScreen(b2 -> {
-				if(b2)
-					itemList.resetToDefaults();
-				client.openScreen(EditItemListScreen.this);
-			}, new LiteralText("Reset to Defaults"),
-				new LiteralText("Are you sure?")))));
-		
-		addButton(
-			doneButton = new ButtonWidget(width / 2 - 100, height - 28, 200, 20,
-				new LiteralText("Done"), b -> client.openScreen(prevScreen)));
+
+		addButton(addButton = new ButtonWidget(width / 2 - 2, height - 56, 30, 20, new LiteralText("Add"), b -> {
+			itemList.add(itemToAdd);
+			itemNameField.setText("");
+		}));
+
+		addButton(removeButton = new ButtonWidget(width / 2 + 52, height - 56, 100, 20,
+				new LiteralText("Remove Selected"), b -> itemList.remove(listGui.selected)));
+
+		addButton(new ButtonWidget(width - 108, 8, 100, 20, new LiteralText("Reset to Defaults"),
+				b -> client.openScreen(new ConfirmScreen(b2 -> {
+					if (b2)
+						itemList.resetToDefaults();
+					client.openScreen(EditItemListScreen.this);
+				}, new LiteralText("Reset to Defaults"), new LiteralText("Are you sure?")))));
+
+		addButton(doneButton = new ButtonWidget(width / 2 - 100, height - 28, 200, 20, new LiteralText("Done"),
+				b -> client.openScreen(prevScreen)));
+
+		addButton(searchTypeButton = new ButtonWidget(8, 8, 130, 20,
+				new LiteralText("Search Type: " + itemList.getSearchType().getCurrent()), b -> {
+					searchTypeButton.setMessage(new LiteralText("Search Type: " + itemList.getSearchType().getNext()));
+				}));
+
 	}
-	
+
 	@Override
-	public boolean mouseClicked(double mouseX, double mouseY, int mouseButton)
-	{
+	public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
 		boolean childClicked = super.mouseClicked(mouseX, mouseY, mouseButton);
-		
+
 		itemNameField.mouseClicked(mouseX, mouseY, mouseButton);
 		listGui.mouseClicked(mouseX, mouseY, mouseButton);
-		
-		if(!childClicked && (mouseX < (width - 220) / 2
-			|| mouseX > width / 2 + 129 || mouseY < 32 || mouseY > height - 64))
+
+		if (!childClicked
+				&& (mouseX < (width - 220) / 2 || mouseX > width / 2 + 129 || mouseY < 32 || mouseY > height - 64))
 			listGui.selected = -1;
-		
+
 		return childClicked;
 	}
-	
+
 	@Override
-	public boolean mouseDragged(double double_1, double double_2, int int_1,
-		double double_3, double double_4)
-	{
+	public boolean mouseDragged(double double_1, double double_2, int int_1, double double_3, double double_4) {
 		listGui.mouseDragged(double_1, double_2, int_1, double_3, double_4);
-		return super.mouseDragged(double_1, double_2, int_1, double_3,
-			double_4);
+		return super.mouseDragged(double_1, double_2, int_1, double_3, double_4);
 	}
-	
+
 	@Override
-	public boolean mouseReleased(double double_1, double double_2, int int_1)
-	{
+	public boolean mouseReleased(double double_1, double double_2, int int_1) {
 		listGui.mouseReleased(double_1, double_2, int_1);
 		return super.mouseReleased(double_1, double_2, int_1);
 	}
-	
+
 	@Override
-	public boolean mouseScrolled(double double_1, double double_2,
-		double double_3)
-	{
+	public boolean mouseScrolled(double double_1, double double_2, double double_3) {
 		listGui.mouseScrolled(double_1, double_2, double_3);
 		return super.mouseScrolled(double_1, double_2, double_3);
 	}
-	
+
 	@Override
-	public boolean keyPressed(int keyCode, int scanCode, int int_3)
-	{
-		if(keyCode == GLFW.GLFW_KEY_ENTER)
+	public boolean keyPressed(int keyCode, int scanCode, int int_3) {
+		if (keyCode == GLFW.GLFW_KEY_ENTER)
 			addButton.onPress();
-		else if(keyCode == GLFW.GLFW_KEY_DELETE)
+		else if (keyCode == GLFW.GLFW_KEY_DELETE)
 			removeButton.onPress();
-		else if(keyCode == GLFW.GLFW_KEY_ESCAPE)
+		else if (keyCode == GLFW.GLFW_KEY_ESCAPE)
 			doneButton.onPress();
-		
+
 		return super.keyPressed(keyCode, scanCode, int_3);
 	}
-	
+
 	@Override
-	public void tick()
-	{
+	public void tick() {
 		itemNameField.tick();
-		
+
 		itemToAdd = Registry.ITEM.get(getItemIDFromField());
-		addButton.active = itemToAdd != null;
-		
-		removeButton.active =
-			listGui.selected >= 0 && listGui.selected < listGui.list.size();
+
+		removeButton.active = listGui.selected >= 0 && listGui.selected < listGui.list.size();
 	}
-	
-	private Identifier getItemIDFromField()
-	{
-		try
-		{
+
+	private Identifier getItemIDFromField() {
+		try {
 			return new Identifier(itemNameField.getText().toLowerCase());
-			
-		}catch(InvalidIdentifierException e)
-		{
+
+		} catch (InvalidIdentifierException e) {
 			return null;
 		}
 	}
-	
+
 	@Override
-	public void render(MatrixStack matrixStack, int mouseX, int mouseY,
-		float partialTicks)
-	{
+	public void render(MatrixStack matrixStack, int mouseX, int mouseY, float partialTicks) {
 		renderBackground(matrixStack);
 		listGui.render(matrixStack, mouseX, mouseY, partialTicks);
-		
-		drawCenteredString(matrixStack, client.textRenderer,
-			itemList.getName() + " (" + listGui.getItemCount() + ")", width / 2,
-			12, 0xffffff);
-		
+
+		drawCenteredString(matrixStack, client.textRenderer, itemList.getName() + " (" + listGui.getItemCount() + ")",
+				width / 2, 12, 0xffffff);
+
 		itemNameField.render(matrixStack, mouseX, mouseY, partialTicks);
 		super.render(matrixStack, mouseX, mouseY, partialTicks);
-		
+
 		GL11.glPushMatrix();
 		GL11.glTranslated(-64 + width / 2 - 152, 0, 0);
-		
-		if(itemNameField.getText().isEmpty() && !itemNameField.isFocused())
-		{
+
+		if (itemNameField.getText().isEmpty() && !itemNameField.isFocused()) {
 			GL11.glPushMatrix();
 			GL11.glTranslated(0, 0, 300);
-			drawStringWithShadow(matrixStack, client.textRenderer,
-				"item name or ID", 68, height - 50, 0x808080);
+			drawStringWithShadow(matrixStack, client.textRenderer, "item name or ID", 68, height - 50, 0x808080);
 			GL11.glPopMatrix();
 		}
-		
+
 		fill(matrixStack, 48, height - 56, 64, height - 36, 0xffa0a0a0);
 		fill(matrixStack, 49, height - 55, 64, height - 37, 0xff000000);
 		fill(matrixStack, 214, height - 56, 244, height - 55, 0xffa0a0a0);
@@ -200,116 +179,104 @@ public final class EditItemListScreen extends Screen
 		fill(matrixStack, 214, height - 40, 243, height - 37, 0xff000000);
 		fill(matrixStack, 215, height - 55, 216, height - 37, 0xff000000);
 		fill(matrixStack, 242, height - 55, 245, height - 37, 0xff000000);
-		listGui.renderIconAndGetName(matrixStack, new ItemStack(itemToAdd), 52,
-			height - 52, false);
-		
+		listGui.renderIconAndGetName(matrixStack, new ItemStack(itemToAdd), 52, height - 52, false);
+
 		GL11.glPopMatrix();
 	}
-	
-	private static class ListGui extends ListWidget
-	{
+
+	private static class ListGui extends ListWidget {
 		private final MinecraftClient mc;
 		private final List<String> list;
 		private int selected = -1;
-		
-		public ListGui(MinecraftClient mc, EditItemListScreen screen,
-			List<String> list)
-		{
+
+		public ListGui(MinecraftClient mc, EditItemListScreen screen, List<String> list) {
 			super(mc, screen.width, screen.height, 32, screen.height - 64, 30);
 			this.mc = mc;
 			this.list = list;
 		}
-		
+
 		@Override
-		protected int getItemCount()
-		{
+		protected int getItemCount() {
 			return list.size();
 		}
-		
+
 		@Override
-		protected boolean selectItem(int index, int int_2, double var3,
-			double var4)
-		{
-			if(index >= 0 && index < list.size())
+		protected boolean selectItem(int index, int int_2, double var3, double var4) {
+			if (index >= 0 && index < list.size())
 				selected = index;
-			
+
 			return true;
 		}
-		
+
 		@Override
-		protected boolean isSelectedItem(int index)
-		{
+		protected boolean isSelectedItem(int index) {
 			return index == selected;
 		}
-		
+
 		@Override
-		protected void renderBackground()
-		{
-			
+		protected void renderBackground() {
+
 		}
-		
+
 		@Override
-		protected void renderItem(MatrixStack matrixStack, int index, int x,
-			int y, int var4, int var5, int var6, float partialTicks)
-		{
+		protected void renderItem(MatrixStack matrixStack, int index, int x, int y, int var4, int var5, int var6,
+				float partialTicks) {
 			String name = list.get(index);
-			Item item = Registry.ITEM.get(new Identifier(name));
+			Item item;
+			try {
+				item = Registry.ITEM.get(new Identifier(name));
+			} catch (Exception e) {
+				item = Registry.ITEM.get(new Identifier("air"));
+			}
 			ItemStack stack = new ItemStack(item);
 			TextRenderer fr = mc.textRenderer;
-			
-			String displayName =
-				renderIconAndGetName(matrixStack, stack, x + 1, y + 1, true);
+
+			String displayName = renderIconAndGetName(matrixStack, stack, x + 1, y + 1, true);
 			fr.draw(matrixStack, displayName, x + 28, y, 0xf0f0f0);
 			fr.draw(matrixStack, name, x + 28, y + 9, 0xa0a0a0);
-			fr.draw(matrixStack, "ID: " + Registry.ITEM.getId(item).toString(),
-				x + 28, y + 18, 0xa0a0a0);
+			fr.draw(matrixStack, "ID: " + Registry.ITEM.getId(item).toString(), x + 28, y + 18, 0xa0a0a0);
 		}
-		
-		private String renderIconAndGetName(MatrixStack matrixStack,
-			ItemStack stack, int x, int y, boolean large)
-		{
-			if(stack.isEmpty())
-			{
+
+		private String renderIconAndGetName(MatrixStack matrixStack, ItemStack stack, int x, int y, boolean large) {
+			if (stack.isEmpty()) {
 				GL11.glPushMatrix();
 				GL11.glTranslated(x, y, 0);
-				if(large)
+				if (large)
 					GL11.glScaled(1.5, 1.5, 1.5);
 				else
 					GL11.glScaled(0.75, 0.75, 0.75);
-				
+
 				DiffuseLighting.enable();
-				mc.getItemRenderer().renderInGuiWithOverrides(
-					new ItemStack(Blocks.GRASS_BLOCK), 0, 0);
+				mc.getItemRenderer().renderInGuiWithOverrides(new ItemStack(Blocks.GRASS_BLOCK), 0, 0);
 				DiffuseLighting.disable();
 				GL11.glPopMatrix();
-				
+
 				GL11.glPushMatrix();
 				GL11.glTranslated(x, y, 0);
-				if(large)
+				if (large)
 					GL11.glScaled(2, 2, 2);
 				GL11.glDisable(GL11.GL_DEPTH_TEST);
 				TextRenderer fr = mc.textRenderer;
 				fr.drawWithShadow(matrixStack, "?", 3, 2, 0xf0f0f0);
 				GL11.glEnable(GL11.GL_DEPTH_TEST);
 				GL11.glPopMatrix();
-				
+
 				return "\u00a7ounknown item\u00a7r";
-				
-			}else
-			{
+
+			} else {
 				GL11.glPushMatrix();
 				GL11.glTranslated(x, y, 0);
-				if(large)
+				if (large)
 					GL11.glScaled(1.5, 1.5, 1.5);
 				else
 					GL11.glScaled(0.75, 0.75, 0.75);
-				
+
 				DiffuseLighting.enable();
 				mc.getItemRenderer().renderInGuiWithOverrides(stack, 0, 0);
 				DiffuseLighting.disable();
-				
+
 				GL11.glPopMatrix();
-				
+
 				return stack.getName().getString();
 			}
 		}

--- a/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
@@ -239,7 +239,6 @@ public final class EditItemListScreen extends Screen {
 			}
 			ItemStack stack = new ItemStack(item);
 			TextRenderer fr = mc.textRenderer;
-
 			String displayName = renderIconAndGetName(matrixStack, stack, x + 1, y + 1, true);
 			fr.draw(matrixStack, displayName, x + 28, y, 0xf0f0f0);
 			fr.draw(matrixStack, name, x + 28, y + 9, 0xa0a0a0);

--- a/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
@@ -63,7 +63,11 @@ public final class EditItemListScreen extends Screen {
 		children.add(itemNameField);
 
 		addButton(addButton = new ButtonWidget(width / 2 - 2, height - 56, 30, 20, new LiteralText("Add"), b -> {
-			itemList.add(itemToAdd);
+			if (itemList.getSearchType() == null) {
+				itemList.add(itemToAdd);
+			} else {
+				itemList.add(itemNameField.getText());
+			}
 			itemNameField.setText("");
 		}));
 
@@ -80,11 +84,13 @@ public final class EditItemListScreen extends Screen {
 		addButton(doneButton = new ButtonWidget(width / 2 - 100, height - 28, 200, 20, new LiteralText("Done"),
 				b -> client.openScreen(prevScreen)));
 
-		addButton(searchTypeButton = new ButtonWidget(8, 8, 130, 20,
-				new LiteralText("Search Type: " + itemList.getSearchType().getCurrent()), b -> {
-					searchTypeButton.setMessage(new LiteralText("Search Type: " + itemList.getSearchType().getNext()));
-				}));
-
+		if (itemList.getSearchType() != null) {
+			addButton(searchTypeButton = new ButtonWidget(8, 8, 130, 20,
+					new LiteralText("Search Type: " + itemList.getSearchType().getCurrent()), b -> {
+						searchTypeButton
+								.setMessage(new LiteralText("Search Type: " + itemList.getSearchType().getNext()));
+					}));
+		}
 	}
 
 	@Override
@@ -136,6 +142,9 @@ public final class EditItemListScreen extends Screen {
 		itemNameField.tick();
 
 		itemToAdd = Registry.ITEM.get(getItemIDFromField());
+		if (itemList.getSearchType() == null) {
+			addButton.active = itemToAdd != null;
+		}
 
 		removeButton.active = listGui.selected >= 0 && listGui.selected < listGui.list.size();
 	}

--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -42,7 +42,7 @@ public final class ItemEspHack extends Hack
 					+ "\u00a7lFancy\u00a7r mode shows larger boxes\n" + "that look better.",
 			BoxSize.values(), BoxSize.FANCY);
 
-	private ItemListSetting itemSearch = new ItemListSetting("Search List",
+	private ItemListSetting itemSearch = new ItemListSetting(new SearchType(), "Search List",
 			"Use this to search for specific items!\n" + SearchType._DISABLED + ": Just marks everything\n"
 					+ SearchType._ITEMID + ": Consider the Id\n" + SearchType._NAME + ": Consider the name\n"
 					+ "(all are case sensitive)",

--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -23,50 +23,50 @@ import net.wurstclient.events.RenderListener;
 import net.wurstclient.events.UpdateListener;
 import net.wurstclient.hack.Hack;
 import net.wurstclient.settings.CheckboxSetting;
+import net.wurstclient.settings.ItemListSetting;
 import net.wurstclient.settings.EnumSetting;
 import net.wurstclient.util.RenderUtils;
 import net.wurstclient.util.RotationUtils;
+import net.wurstclient.util.SearchType;
 
-@SearchTags({"item esp", "ItemTracers", "item tracers"})
-public final class ItemEspHack extends Hack implements UpdateListener,
-	CameraTransformViewBobbingListener, RenderListener
-{
-	private final CheckboxSetting names = new CheckboxSetting("Show item names",
-		"Sorry, this is currently broken!\n"
-			+ "19w39a changed how nameplates work\n"
-			+ "and we haven't figured it out yet.",
-		true);
-	
-	private final EnumSetting<Style> style =
-		new EnumSetting<>("Style", Style.values(), Style.BOXES);
-	
+@SearchTags({ "item esp", "ItemTracers", "item tracers" })
+public final class ItemEspHack extends Hack
+		implements UpdateListener, CameraTransformViewBobbingListener, RenderListener {
+	private final CheckboxSetting names = new CheckboxSetting("Show item names", "Sorry, this is currently broken!\n"
+			+ "19w39a changed how nameplates work\n" + "and we haven't figured it out yet.", true);
+
+	private final EnumSetting<Style> style = new EnumSetting<>("Style", Style.values(), Style.BOXES);
+
 	private final EnumSetting<BoxSize> boxSize = new EnumSetting<>("Box size",
-		"\u00a7lAccurate\u00a7r mode shows the exact\n"
-			+ "hitbox of each item.\n"
-			+ "\u00a7lFancy\u00a7r mode shows larger boxes\n"
-			+ "that look better.",
-		BoxSize.values(), BoxSize.FANCY);
-	
+			"\u00a7lAccurate\u00a7r mode shows the exact\n" + "hitbox of each item.\n"
+					+ "\u00a7lFancy\u00a7r mode shows larger boxes\n" + "that look better.",
+			BoxSize.values(), BoxSize.FANCY);
+
+	private ItemListSetting itemSearch = new ItemListSetting("Search List",
+			"Use this to search for specific items!\n" + SearchType._DISABLED + ": Just marks everything\n"
+					+ SearchType._ITEMID + ": Consider the Id\n" + SearchType._NAME + ": Consider the name\n"
+					+ "(all are case sensitive)",
+			"");
+
 	private int itemBox;
 	private final ArrayList<ItemEntity> items = new ArrayList<>();
-	
-	public ItemEspHack()
-	{
+
+	public ItemEspHack() {
 		super("ItemESP", "Highlights nearby items.");
 		setCategory(Category.RENDER);
-		
+
 		addSetting(names);
 		addSetting(style);
 		addSetting(boxSize);
+		addSetting(itemSearch);
 	}
-	
+
 	@Override
-	public void onEnable()
-	{
+	public void onEnable() {
 		EVENTS.add(UpdateListener.class, this);
 		EVENTS.add(CameraTransformViewBobbingListener.class, this);
 		EVENTS.add(RenderListener.class, this);
-		
+
 		itemBox = GL11.glGenLists(1);
 		GL11.glNewList(itemBox, GL11.GL_COMPILE);
 		GL11.glEnable(GL11.GL_BLEND);
@@ -77,57 +77,75 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 		RenderUtils.drawOutlinedBox(new Box(-0.5, 0, -0.5, 0.5, 1, 0.5));
 		GL11.glEndList();
 	}
-	
+
 	@Override
-	public void onDisable()
-	{
+	public void onDisable() {
 		EVENTS.remove(UpdateListener.class, this);
 		EVENTS.remove(CameraTransformViewBobbingListener.class, this);
 		EVENTS.remove(RenderListener.class, this);
-		
+
 		GL11.glDeleteLists(itemBox, 1);
 	}
-	
+
 	@Override
-	public void onUpdate()
-	{
+	public void onUpdate() {
 		items.clear();
-		for(Entity entity : MC.world.getEntities())
-			if(entity instanceof ItemEntity)
-				items.add((ItemEntity)entity);
+		switch (itemSearch.getSearchType().getCurrent()) {
+			case SearchType._ITEMID:
+				for (Entity entity : MC.world.getEntities()) {
+					if (entity instanceof ItemEntity) {
+						if (itemSearch.containsItemId(((ItemEntity) entity).getStack().getItem())) {
+							items.add((ItemEntity) entity);
+						}
+					}
+				}
+				break;
+			case SearchType._NAME:
+				for (Entity entity : MC.world.getEntities()) {
+					if (entity instanceof ItemEntity) {
+						if (itemSearch.containsItemName(((ItemEntity) entity).getStack())) {
+							items.add((ItemEntity) entity);
+						}
+					}
+				}
+				break;
+			default:
+				for (Entity entity : MC.world.getEntities()) {
+					if (entity instanceof ItemEntity) {
+						items.add((ItemEntity) entity);
+					}
+				}
+		}
 	}
-	
+
 	@Override
-	public void onCameraTransformViewBobbing(
-		CameraTransformViewBobbingEvent event)
-	{
-		if(style.getSelected().lines)
+	public void onCameraTransformViewBobbing(CameraTransformViewBobbingEvent event) {
+		if (style.getSelected().lines)
 			event.cancel();
 	}
-	
+
 	@Override
-	public void onRender(float partialTicks)
-	{
+	public void onRender(float partialTicks) {
 		// GL settings
 		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		GL11.glEnable(GL11.GL_LINE_SMOOTH);
 		GL11.glLineWidth(2);
 		GL11.glDisable(GL11.GL_LIGHTING);
-		
+
 		GL11.glPushMatrix();
 		RenderUtils.applyRegionalRenderOffset();
-		
+
 		BlockPos camPos = RenderUtils.getCameraBlockPos();
 		int regionX = (camPos.getX() >> 9) * 512;
 		int regionZ = (camPos.getZ() >> 9) * 512;
-		
+
 		renderBoxes(partialTicks, regionX, regionZ);
-		
-		if(style.getSelected().lines)
+
+		if (style.getSelected().lines)
 			renderTracers(partialTicks, regionX, regionZ);
-		
+
 		GL11.glPopMatrix();
-		
+
 		// GL resets
 		GL11.glColor4f(1, 1, 1, 1);
 		GL11.glEnable(GL11.GL_DEPTH_TEST);
@@ -135,31 +153,25 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 		GL11.glDisable(GL11.GL_BLEND);
 		GL11.glDisable(GL11.GL_LINE_SMOOTH);
 	}
-	
-	private void renderBoxes(double partialTicks, int regionX, int regionZ)
-	{
+
+	private void renderBoxes(double partialTicks, int regionX, int regionZ) {
 		double extraSize = boxSize.getSelected().extraSize;
-		
-		for(ItemEntity e : items)
-		{
+
+		for (ItemEntity e : items) {
 			GL11.glPushMatrix();
-			
-			GL11.glTranslated(
-				e.prevX + (e.getX() - e.prevX) * partialTicks - regionX,
-				e.prevY + (e.getY() - e.prevY) * partialTicks,
-				e.prevZ + (e.getZ() - e.prevZ) * partialTicks - regionZ);
-			
-			if(style.getSelected().boxes)
-			{
+
+			GL11.glTranslated(e.prevX + (e.getX() - e.prevX) * partialTicks - regionX,
+					e.prevY + (e.getY() - e.prevY) * partialTicks,
+					e.prevZ + (e.getZ() - e.prevZ) * partialTicks - regionZ);
+
+			if (style.getSelected().boxes) {
 				GL11.glPushMatrix();
-				GL11.glScaled(e.getWidth() + extraSize,
-					e.getHeight() + extraSize, e.getWidth() + extraSize);
+				GL11.glScaled(e.getWidth() + extraSize, e.getHeight() + extraSize, e.getWidth() + extraSize);
 				GL11.glCallList(itemBox);
 				GL11.glPopMatrix();
 			}
-			
-			if(names.isChecked())
-			{
+
+			if (names.isChecked()) {
 				// ItemStack stack = e.getStack();
 				// GameRenderer.renderFloatingText(MC.textRenderer,
 				// stack.getCount() + "x "
@@ -168,76 +180,63 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 				// MC.getEntityRenderManager().cameraPitch, false);
 				// GL11.glDisable(GL11.GL_LIGHTING);
 			}
-			
+
 			GL11.glPopMatrix();
 		}
 	}
-	
-	private void renderTracers(double partialTicks, int regionX, int regionZ)
-	{
+
+	private void renderTracers(double partialTicks, int regionX, int regionZ) {
 		GL11.glEnable(GL11.GL_BLEND);
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 		GL11.glDisable(GL11.GL_DEPTH_TEST);
 		GL11.glColor4f(1, 1, 0, 0.5F);
-		
-		Vec3d start =
-			RotationUtils.getClientLookVec().add(RenderUtils.getCameraPos());
-		
+
+		Vec3d start = RotationUtils.getClientLookVec().add(RenderUtils.getCameraPos());
+
 		GL11.glBegin(GL11.GL_LINES);
-		for(ItemEntity e : items)
-		{
-			Vec3d end = e.getBoundingBox().getCenter()
-				.subtract(new Vec3d(e.getX(), e.getY(), e.getZ())
-					.subtract(e.prevX, e.prevY, e.prevZ)
-					.multiply(1 - partialTicks));
-			
+		for (ItemEntity e : items) {
+			Vec3d end = e.getBoundingBox().getCenter().subtract(new Vec3d(e.getX(), e.getY(), e.getZ())
+					.subtract(e.prevX, e.prevY, e.prevZ).multiply(1 - partialTicks));
+
 			GL11.glVertex3d(start.x - regionX, start.y, start.z - regionZ);
 			GL11.glVertex3d(end.x - regionX, end.y, end.z - regionZ);
 		}
 		GL11.glEnd();
 	}
-	
-	private enum Style
-	{
-		BOXES("Boxes only", true, false),
-		LINES("Lines only", false, true),
+
+	private enum Style {
+		BOXES("Boxes only", true, false), LINES("Lines only", false, true),
 		LINES_AND_BOXES("Lines and boxes", true, true);
-		
+
 		private final String name;
 		private final boolean boxes;
 		private final boolean lines;
-		
-		private Style(String name, boolean boxes, boolean lines)
-		{
+
+		private Style(String name, boolean boxes, boolean lines) {
 			this.name = name;
 			this.boxes = boxes;
 			this.lines = lines;
 		}
-		
+
 		@Override
-		public String toString()
-		{
+		public String toString() {
 			return name;
 		}
 	}
-	
-	private enum BoxSize
-	{
-		ACCURATE("Accurate", 0),
-		FANCY("Fancy", 0.1);
-		
+
+	private enum BoxSize {
+		ACCURATE("Accurate", 0), FANCY("Fancy", 0.1);
+
 		private final String name;
 		private final double extraSize;
-		
-		private BoxSize(String name, double extraSize)
-		{
+
+		private BoxSize(String name, double extraSize) {
 			this.name = name;
 			this.extraSize = extraSize;
 		}
-		
+
 		@Override
-		public String toString()
-		{
+		public String toString() {
 			return name;
 		}
 	}

--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -43,9 +43,9 @@ public final class ItemEspHack extends Hack
 			BoxSize.values(), BoxSize.FANCY);
 
 	private ItemListSetting itemSearch = new ItemListSetting(new SearchType(), "Search List",
-			"Use this to search for specific items!\n" + SearchType._DISABLED + ": Just marks everything\n"
-					+ SearchType._ITEMID + ": Consider the Id\n" + SearchType._NAME + ": Consider the name\n"
-					+ "(all are case sensitive)",
+			"Use this to search for specific items!\n" + SearchType._DISABLED + ": Will disable the setting\n"
+					+ SearchType._ITEMID + ": Each input name is actually an item id\n" + SearchType._NAME
+					+ ": Each input name is the name of an item\n",
 			"");
 
 	private int itemBox;

--- a/src/main/java/net/wurstclient/settings/ItemListSetting.java
+++ b/src/main/java/net/wurstclient/settings/ItemListSetting.java
@@ -35,14 +35,25 @@ import net.wurstclient.util.SearchType;
 public final class ItemListSetting extends Setting {
 	private final ArrayList<String> itemNames = new ArrayList<>();
 	private final String[] defaultNames;
-	private final SearchType searchType = new SearchType();
+	private SearchType searchType = null;
 
 	public ItemListSetting(String name, String description, String... items) {
 		super(name, description);
-
 		Arrays.stream(items).parallel().map(s -> Registry.ITEM.get(new Identifier(s))).filter(Objects::nonNull)
 				.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted().forEachOrdered(s -> itemNames.add(s));
 		defaultNames = itemNames.toArray(new String[0]);
+	}
+
+	public ItemListSetting(SearchType sType, String name, String description, String... items) {
+		super(name, description);
+		searchType = sType;
+		Arrays.stream(items).parallel().map(s -> Registry.ITEM.get(new Identifier(s))).filter(Objects::nonNull)
+				.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted().forEachOrdered(s -> itemNames.add(s));
+		defaultNames = itemNames.toArray(new String[0]);
+	}
+
+	public void setSearchType(SearchType sType) {
+		this.searchType = sType;
 	}
 
 	public SearchType getSearchType() {
@@ -80,10 +91,8 @@ public final class ItemListSetting extends Setting {
 	}
 
 	public void add(String name) {
-
-		if (Collections.binarySearch(itemNames, name) >= 0) {
+		if (Collections.binarySearch(itemNames, name) >= 0)
 			return;
-		}
 
 		itemNames.add(name);
 		Collections.sort(itemNames);

--- a/src/main/java/net/wurstclient/settings/ItemListSetting.java
+++ b/src/main/java/net/wurstclient/settings/ItemListSetting.java
@@ -73,7 +73,11 @@ public final class ItemListSetting extends Setting {
 	}
 
 	private Identifier getRegistryId(String str) {
-		return Registry.ITEM.getId(Registry.ITEM.get(new Identifier(str.toLowerCase())));
+		try {
+			return Registry.ITEM.getId(Registry.ITEM.get(new Identifier(str.toLowerCase())));
+		} catch (Exception e) {
+			return Registry.ITEM.getId(Registry.ITEM.get(new Identifier("air")));
+		}
 	}
 
 	public List<String> getItemNames() {

--- a/src/main/java/net/wurstclient/settings/ItemListSetting.java
+++ b/src/main/java/net/wurstclient/settings/ItemListSetting.java
@@ -14,11 +14,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.wurstclient.WurstClient;
@@ -28,94 +30,120 @@ import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
 import net.wurstclient.util.json.WsonArray;
+import net.wurstclient.util.SearchType;
 
-public final class ItemListSetting extends Setting
-{
+public final class ItemListSetting extends Setting {
 	private final ArrayList<String> itemNames = new ArrayList<>();
 	private final String[] defaultNames;
-	
-	public ItemListSetting(String name, String description, String... items)
-	{
+	private final SearchType searchType = new SearchType();
+
+	public ItemListSetting(String name, String description, String... items) {
 		super(name, description);
-		
-		Arrays.stream(items).parallel()
-			.map(s -> Registry.ITEM.get(new Identifier(s)))
-			.filter(Objects::nonNull)
-			.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted()
-			.forEachOrdered(s -> itemNames.add(s));
+
+		Arrays.stream(items).parallel().map(s -> Registry.ITEM.get(new Identifier(s))).filter(Objects::nonNull)
+				.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted().forEachOrdered(s -> itemNames.add(s));
 		defaultNames = itemNames.toArray(new String[0]);
 	}
-	
-	public List<String> getItemNames()
-	{
+
+	public SearchType getSearchType() {
+		return this.searchType;
+	}
+
+	public boolean containsItemName(ItemStack stack) {
+		String nameToSearch = stack.getName().getString();
+		Predicate<String> predicate = str -> str.equals(nameToSearch);
+		return itemNames.stream().anyMatch(predicate);
+	}
+
+	public boolean containsItemId(Item item) {
+		String idToSearch = (Registry.ITEM.getId(item)).toString();
+		Predicate<String> predicate = str -> getRegistryId(str).toString().equals(idToSearch);
+		return itemNames.stream().anyMatch(predicate);
+	}
+
+	private Identifier getRegistryId(String str) {
+		return Registry.ITEM.getId(Registry.ITEM.get(new Identifier(str.toLowerCase())));
+	}
+
+	public List<String> getItemNames() {
 		return Collections.unmodifiableList(itemNames);
 	}
-	
-	public void add(Item item)
-	{
+
+	public void add(Item item) {
 		String name = Registry.ITEM.getId(item).toString();
-		if(Collections.binarySearch(itemNames, name) >= 0)
+		if (Collections.binarySearch(itemNames, name) >= 0)
 			return;
-		
+
 		itemNames.add(name);
 		Collections.sort(itemNames);
 		WurstClient.INSTANCE.saveSettings();
 	}
-	
-	public void remove(int index)
-	{
-		if(index < 0 || index >= itemNames.size())
+
+	public void add(String name) {
+
+		if (Collections.binarySearch(itemNames, name) >= 0) {
 			return;
-		
+		}
+
+		itemNames.add(name);
+		Collections.sort(itemNames);
+		WurstClient.INSTANCE.saveSettings();
+	}
+
+	public void remove(int index) {
+		if (index < 0 || index >= itemNames.size())
+			return;
+
 		itemNames.remove(index);
 		WurstClient.INSTANCE.saveSettings();
 	}
-	
-	public void resetToDefaults()
-	{
+
+	public void resetToDefaults() {
 		itemNames.clear();
 		itemNames.addAll(Arrays.asList(defaultNames));
 		WurstClient.INSTANCE.saveSettings();
 	}
-	
+
 	@Override
-	public Component getComponent()
-	{
+	public Component getComponent() {
 		return new ItemListEditButton(this);
 	}
-	
+
 	@Override
-	public void fromJson(JsonElement json)
-	{
-		try
-		{
+	public void fromJson(JsonElement json) {
+		try {
 			WsonArray wson = JsonUtils.getAsArray(json);
 			itemNames.clear();
-			
-			wson.getAllStrings().parallelStream()
-				.map(s -> Registry.ITEM.get(new Identifier(s)))
-				.filter(Objects::nonNull)
-				.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted()
-				.forEachOrdered(s -> itemNames.add(s));
-			
-		}catch(JsonException e)
-		{
+
+			wson.getAllStrings().parallelStream().map(s -> {
+				try {
+					return Registry.ITEM.get(new Identifier(s));
+				} catch (Exception e) {
+					return s;
+				}
+			}).filter(Objects::nonNull).map(i -> {
+				if (i instanceof Item) {
+					return Registry.ITEM.getId((Item) i).toString();
+				} else {
+					return (String) i;
+				}
+			}).distinct().sorted().forEachOrdered(s -> itemNames.add(s));
+
+		} catch (JsonException e) {
 			e.printStackTrace();
 			resetToDefaults();
 		}
 	}
-	
+
 	@Override
-	public JsonElement toJson()
-	{
+	public JsonElement toJson() {
 		JsonArray json = new JsonArray();
 		itemNames.forEach(s -> json.add(s));
 		return json;
 	}
-	
+
 	@Override
-	public Set<PossibleKeybind> getPossibleKeybinds(String featureName)
-	{
+	public Set<PossibleKeybind> getPossibleKeybinds(String featureName) {
 		return new LinkedHashSet<>();
 	}
 }

--- a/src/main/java/net/wurstclient/util/SearchType.java
+++ b/src/main/java/net/wurstclient/util/SearchType.java
@@ -1,0 +1,28 @@
+package net.wurstclient.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class SearchType {
+    public static final String _ITEMID = "Item Id";
+    public static final String _NAME = "Item name";
+    public static final String _DISABLED = "Disabled";
+    private ArrayList<String> list = new ArrayList<String>(Arrays.asList(_DISABLED, _ITEMID, _NAME));
+    private String current = list.get(0);
+
+    public SearchType() {
+
+    }
+
+    public String getCurrent() {
+        return this.current;
+    }
+
+    public String getNext() {
+        int currentIndex = list.indexOf(this.current);
+        int listSize = list.size() - 1;
+        int increment = currentIndex != listSize ? 1 : -listSize;
+        this.current = list.get(currentIndex + increment);
+        return this.current;
+    }
+}


### PR DESCRIPTION
### **Description**
A new setting in ItemESP which turns possible to mark only the items that you want.

### **Search Type**
There are 3 options:
_1. Disable_ (Will disable the setting)
_2. Item Id_ (Each input name is actually an item id)
_3. Item name_ (Each input name is the name of an item)

### **How to use**
There's a setting named "Search List" and to the side, a button named "Edit...", click on it to open a list, if you want to mark only diamonds just toggle the "Search Type" button to "Item Id", this will consider the typed names as the item ID, on the other hand, if you want to search for specific item names, set the toggle button to "Item name" and insert the name of the item(this is case sensitive and can detect items with modified names).
