### PR TITLE
noSlowdown improvements

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
@@ -10,14 +10,53 @@ package net.wurstclient.hacks;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
 
 @SearchTags({"no slowdown", "no slow down"})
 public final class NoSlowdownHack extends Hack
 {
+	private final CheckboxSetting noIce = new CheckboxSetting(
+			"No ice", "Prevent ice slipperiness\n",
+			false);
+	
+	private final CheckboxSetting honeyJump = new CheckboxSetting(
+			"Honey jump", "Allow jumping on honey\n",
+			true);
+	
+	private final CheckboxSetting slimeUtil = new CheckboxSetting(
+			"Slime utiltiy", "Removes bouncing and disables slowdown\n"
+					+ "\u00A74Don't disable this while on a slime block\u00A7r\n"
+					+ "Slime still negates falldamage",
+			false);
+	
 	public NoSlowdownHack()
 	{
 		super("NoSlowdown", "Cancels slowness effects caused by\n"
 			+ "honey, soul sand and using items.");
 		setCategory(Category.MOVEMENT);
+		addSetting(honeyJump);
+		addSetting(noIce);
+		addSetting(slimeUtil);
+	}
+	
+	public boolean getNoIce()
+	{
+	if (noIce.isChecked())
+		return true;
+	    return false;
+	}
+	
+	public boolean getHoneyJump()
+	{
+	if (honeyJump.isChecked())
+		return true;
+		return false;
+	}
+	
+	public boolean getSlimeUtil()
+	{
+	if (slimeUtil.isChecked())
+		return true;
+		return false;
 	}
 }

--- a/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
@@ -41,22 +41,16 @@ public final class NoSlowdownHack extends Hack
 	
 	public boolean getNoIce()
 	{
-	if (noIce.isChecked())
-		return true;
-	        return false;
+		return noIce.isChecked();
 	}
 	
 	public boolean getHoneyJump()
 	{
-	if (honeyJump.isChecked())
-		return true;
-		return false;
+		return honeyJump.isChecked();
 	}
 	
 	public boolean getSlimeUtil()
 	{
-	if (slimeUtil.isChecked())
-		return true;
-		return false;
+		return slimeUtil.isChecked();
 	}
 }

--- a/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
@@ -43,7 +43,7 @@ public final class NoSlowdownHack extends Hack
 	{
 	if (noIce.isChecked())
 		return true;
-	    return false;
+	        return false;
 	}
 	
 	public boolean getHoneyJump()

--- a/src/main/java/net/wurstclient/mixin/BlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockMixin.java
@@ -53,4 +53,30 @@ public abstract class BlockMixin implements ItemConvertible
 		if(cir.getReturnValueF() < 1)
 			cir.setReturnValue(1F);
 	}
+	
+	@Inject(at = {@At("HEAD")},
+			method = {"getSlipperiness()F"},
+			cancellable = true)
+		private void onGetSlipperiness(CallbackInfoReturnable<Float> cir)
+		{
+			HackList hax = WurstClient.INSTANCE.getHax();
+			if(hax == null || !hax.noSlowdownHack.isEnabled() || !hax.noSlowdownHack.getNoIce())
+				return;
+			
+			if(cir.getReturnValueF() < 0.6)
+				cir.setReturnValue(0.6F);
+		}
+	
+	@Inject(at = {@At("HEAD")},
+			method = {"getJumpVelocityMultiplier()F"},
+			cancellable = true)
+		private void onGetJumpVelocityMultiplier(CallbackInfoReturnable<Float> cir)
+		{
+			HackList hax = WurstClient.INSTANCE.getHax();
+			if(hax == null || !hax.noSlowdownHack.isEnabled() || !hax.noSlowdownHack.getHoneyJump())
+				return;
+			
+			if(cir.getReturnValueF() < 1)
+				cir.setReturnValue(1F);
+		}
 }

--- a/src/main/java/net/wurstclient/mixin/SlimeBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/SlimeBlockMixin.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SlimeBlock;
+import net.minecraft.block.TransparentBlock;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.wurstclient.WurstClient;
+
+@Mixin(SlimeBlock.class)
+public abstract class SlimeBlockMixin extends TransparentBlock
+{
+	private SlimeBlockMixin(WurstClient wurst, Settings block$Settings_1) 
+	{
+		super(block$Settings_1);	
+	}
+	
+	// Cancels bouncing, which in turn also removes slowdown
+	@Inject(at = {@At("HEAD")},
+			method = {
+				"bounce(Lnet/minecraft/entity/Entity;)V"},
+			cancellable = true)
+	private void onBounce(Entity entity, CallbackInfo ci)
+	{
+		if(WurstClient.INSTANCE.getHax().noSlowdownHack.getSlimeUtil())
+		ci.cancel();
+	}
+	
+	// Smooth transition from normal block to slime block
+	@Inject(at = { @At("HEAD") },
+			method = {
+				"onSteppedOn(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/entity/Entity;)V" },
+			cancellable = true)
+	private void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) 
+	{
+		if (WurstClient.INSTANCE.getHax().noSlowdownHack.getSlimeUtil())
+			ci.cancel();
+			
+	}
+
+}

--- a/src/main/java/net/wurstclient/mixin/SlimeBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/SlimeBlockMixin.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.wurstclient.WurstClient;
+import net.wurstclient.hacks.NoSlowdownHack;
 
 @Mixin(SlimeBlock.class)
 public abstract class SlimeBlockMixin extends TransparentBlock

--- a/src/main/java/net/wurstclient/mixin/SlimeBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/SlimeBlockMixin.java
@@ -35,7 +35,8 @@ public abstract class SlimeBlockMixin extends TransparentBlock
 			cancellable = true)
 	private void onBounce(Entity entity, CallbackInfo ci)
 	{
-		if(WurstClient.INSTANCE.getHax().noSlowdownHack.getSlimeUtil())
+		NoSlowdownHack hax = WurstClient.INSTANCE.getHax().noSlowdownHack;
+		if(hax.isEnabled() && hax.getSlimeUtil())
 		ci.cancel();
 	}
 	
@@ -46,7 +47,8 @@ public abstract class SlimeBlockMixin extends TransparentBlock
 			cancellable = true)
 	private void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) 
 	{
-		if (WurstClient.INSTANCE.getHax().noSlowdownHack.getSlimeUtil())
+		NoSlowdownHack hax = WurstClient.INSTANCE.getHax().noSlowdownHack;
+		if (hax.isEnabled() && hax.getSlimeUtil())
 			ci.cancel();
 			
 	}

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -50,6 +50,7 @@
     "ServerListMixin",
     "ShulkerBoxScreenMixin",
     "SignEditScreenMixin",
+    "SlimeBlockMixin",
     "StatsScreenMixin",
     "StatusEffectInstanceMixin",
     "SwordItemMixin",


### PR DESCRIPTION
Added an option for no ice (no slipperiness)
Added an option to allow jumping on a honey block
Added an option to remove slowdown and bounciness from slime block

https://user-images.githubusercontent.com/61437644/122626006-b4bc6880-d0b0-11eb-8aaa-ff6e4a3c7f30.mp4



If you enable the "slime utilities", then jump a bunch on some slime and disable the checkbox while standing on a slime block, then your previous bounces are re-remembered and combined and you get skyrocketed upwards. 
It's only a little inconvenient and needs extremely precise conditions to happen, so I didn't bother to find a way to fix it.