### PR TITLE
Open a GPL exception to linking with Minecraft.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ https://www.wurstclient.net/download/
 
 This code is licensed under the GNU General Public License v3. **You can only use this code in open-source clients that you release under the same license! Using it in closed-source/proprietary clients is not allowed!**
 
+As a special exception, the copyright holders of this Program give you permission to use the Program with the Minecraft Client, regardless of the license terms of the Minecraft Game. The Minecraft "Game" refers to the Minecraft game engine, the Mojang Launchwrapper, the Mojang AuthLib and the Minecraft Realms library (and/or modified versions of said software), as long as license terms of said software are followed.
+
 ## Note about Pull Requests
 
 If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for us to add your features, as we have to test, validate and add them one by one.


### PR DESCRIPTION
The current licensing under the GPL is partially not valid because of technicalities where software linked with a GPL license has to be GPL as well. This PR adds an exception to the "License" section of the README to fix this issue, and make the license fully valid and enforceable again.
