### PR TITLE
Added null ckeck Before Calling tree.close();

### DIFF
--- a/src/main/java/net/wurstclient/hacks/TreeBotHack.java
+++ b/src/main/java/net/wurstclient/hacks/TreeBotHack.java
@@ -113,8 +113,12 @@ public final class TreeBotHack extends Hack
 		angleFinder = null;
 		processor = null;
 		
-		tree.close();
-		tree = null;
+		
+		if(tree != null)
+		{
+			tree.close();
+			tree = null;
+		}
 		
 		if(currentBlock != null)
 		{


### PR DESCRIPTION
## Description
Fixing game crash when deactivating Tree Bot caused by tree being null
### Error / Stack Trace
[STDERR]: java.lang.NullPointerException: Cannot invoke "net.wurstclient.treebot.Tree.close()" because "this.tree" is null
[STDERR]: 	at net.wurstclient.hacks.TreeBotHack.onDisable(TreeBotHack.java:116)
