### PR TITLE
Fix MobSpawnESP NPE

### DIFF
--- a/src/main/java/net/wurstclient/hacks/MobSpawnEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/MobSpawnEspHack.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 import org.lwjgl.opengl.GL11;
 
@@ -367,6 +368,7 @@ public final class MobSpawnEspHack extends Hack
 				});
 			
 			new ArrayList<>(yellow).stream()
+				.filter(Objects::nonNull)
 				.map(pos -> new BlockPos(pos.getX() - regionX, pos.getY(),
 					pos.getZ() - regionZ))
 				.forEach(pos -> {


### PR DESCRIPTION
## Description
Related issue: #467 
After rigorously testing it seems that sometimes inside a stream map the variable is null, added null check.

Kept placing blocks mid air and destroying them in creative mode tons of times in quick succession, eventually game crashed with the exact same log from the related issue.


