### PR TITLE
Fixed bug with buildrandom opening containers

### DIFF
--- a/src/main/java/net/wurstclient/hacks/BuildRandomHack.java
+++ b/src/main/java/net/wurstclient/hacks/BuildRandomHack.java
@@ -19,6 +19,7 @@ import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -218,6 +219,11 @@ public final class BuildRandomHack extends Hack
 			if(distanceSqPosVec > eyesPos.squaredDistanceTo(posVec.add(dirVec)))
 				continue;
 			
+			// check if block can be interacted with (chest, crafting table, ...)
+			BlockHitResult hitResult = new BlockHitResult(hitVec, side.getOpposite(), neighbor, false);
+			if (MC.world.getBlockState(neighbor).onUse(MC.world, MC.player, Hand.MAIN_HAND, hitResult).isAccepted())
+				continue;
+			
 			// check line of sight
 			if(MC.world
 				.raycast(new RaycastContext(eyesPos, hitVec,
@@ -262,6 +268,11 @@ public final class BuildRandomHack extends Hack
 			
 			// check if hitVec is within range (6 blocks)
 			if(eyesPos.squaredDistanceTo(hitVec) > 36)
+				continue;
+			
+			// check if block can be interacted with (chest, crafting table, ...)
+			BlockHitResult hitResult = new BlockHitResult(hitVec, side.getOpposite(), neighbor, false);
+			if (MC.world.getBlockState(neighbor).onUse(MC.world, MC.player, Hand.MAIN_HAND, hitResult).isAccepted())
 				continue;
 			
 			// place block


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
Buildrandom would sometimes try to place blocks in the location of a container, causing the player to open the container instead of placing the block. This PR fixes this by preventing blocks from being placed in such locations.