### PR TITLE
Fix ChestESP for Barrels

### DIFF
--- a/src/main/java/net/wurstclient/mixin/BarrelBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BarrelBlockMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package net.wurstclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.block.BarrelBlock;
+import net.minecraft.block.BlockEntityProvider;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityTicker;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+// Implements getTicker for barrels so that it can be seen by ChestESP
+@Mixin(BarrelBlock.class)
+public abstract class BarrelBlockMixin implements BlockEntityProvider
+{
+    // This takes a BlockEntity but it will receive a BarrelBlockEntity
+    private static void clientTick(World world, BlockPos pos, BlockState state, BlockEntity blockEntity)
+    {
+        // Does absolutely nothing
+        // A normal chest would animate here.
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state, BlockEntityType<T> type)
+    {
+        // This imitates other Ticker functions and manually inlines `checkType`
+        if (world.isClient && type == BlockEntityType.BARREL)
+            return BarrelBlockMixin::clientTick;
+        else
+            return null;
+    }
+}

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -8,6 +8,7 @@
   	"AbstractBlockStateMixin",
     "ArmorItemMixin",
     "BackgroundRendererMixin",
+    "BarrelBlockMixin",
   	"BlockEntityRenderDispatcherMixin",
   	"BlockMixin",
   	"BlockModelRendererMixin",


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
Fixes #439
Barrels no longer (? I am uncertain if they had it in previous versions or not) had a `getTicker` method. This meant that `getBlockEntityTickers` would not include barrels at all, and thus barrels would not get highlighted.  
  
This mixin simply implements a basic (no-op) ticker for the `BarrelBlock`. This seemed the simplest way to approach the problem while also keeping the implementation of ChestESP to use tickers. Though, if ChestESP was ever switched over to searching for the container blocks, then the mixin can simply be removed.

## (Optional) screenshots / videos
![2021-11-23_22 38 52](https://user-images.githubusercontent.com/94941415/143177563-bb43d680-34ca-45fc-9f72-7f6cdde37a54.png)

