### PR TITLE
Added sorting capability to AutoStealHack

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ContainerScreen54Mixin.java
+++ b/src/main/java/net/wurstclient/mixin/ContainerScreen54Mixin.java
@@ -7,6 +7,7 @@
  */
 package net.wurstclient.mixin;
 
+import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,6 +24,8 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.wurstclient.WurstClient;
 import net.wurstclient.hacks.AutoStealHack;
+
+import java.util.*;
 
 @Mixin(GenericContainerScreen.class)
 public abstract class ContainerScreen54Mixin
@@ -54,6 +57,9 @@ public abstract class ContainerScreen54Mixin
 		
 		if(autoSteal.areButtonsVisible())
 		{
+			addDrawableChild(new ButtonWidget(x + backgroundWidth - 160, y + 4,
+				50, 12, new LiteralText("Sort"), b -> sort()));
+
 			addDrawableChild(new ButtonWidget(x + backgroundWidth - 108, y + 4,
 				50, 12, new LiteralText("Steal"), b -> steal()));
 			
@@ -118,4 +124,166 @@ public abstract class ContainerScreen54Mixin
 			throw new RuntimeException(e);
 		}
 	}
+
+
+	private void sort()
+	{
+		runInThread(() -> sortInThread(0, rows * 9, 3));
+	}
+
+	private void sortInThread(int from, int to, int mode)
+	{
+		this.mode = mode;
+
+		final List<Integer> orderedSlots = getOrderedSlots(from, to);
+		final Set<Integer> remainingSlots = new HashSet<>(orderedSlots);
+		final Map<Integer, Integer> oldPosToNewPosMapping = getOldPosToNewPosMapping(orderedSlots);
+
+		if(remainingSlots.stream().findFirst().isPresent())
+			runInThread(() -> replaceSlot(remainingSlots, oldPosToNewPosMapping, -1));
+	}
+
+	/**
+	 * Recursive method to sort a single Slot
+	 * The break condition is `remainingSlots` being empty.
+	 *
+	 * @param remainingSlots A set of remaining slot positions that are not sorted yet
+	 * @param oldPosToNewPosMapping A map binding old slot positions to their new sorted one
+	 * @param cursorOldPosition The slot position from which the current Cursor Stack originated
+	 */
+	private void replaceSlot(final Set<Integer> remainingSlots, final Map<Integer, Integer> oldPosToNewPosMapping,
+							 final int cursorOldPosition) {
+
+		final int sourcePosition;
+		final int targetPosition;
+		ItemStack cursorStack = handler.getCursorStack();
+
+		if(cursorStack.isEmpty())
+		{
+			final Optional<Integer> remainingSlotOpt = remainingSlots.stream().findFirst();
+			if(remainingSlotOpt.isEmpty())
+				return;
+
+			final int nextSourcePosition = remainingSlotOpt.get();
+
+			sourcePosition = nextSourcePosition;
+			targetPosition = oldPosToNewPosMapping.get(nextSourcePosition);
+		}
+		else
+		{
+			sourcePosition = cursorOldPosition;
+			targetPosition = oldPosToNewPosMapping.get(cursorOldPosition);
+		}
+
+		if(sourcePosition != targetPosition)
+		{
+			if(cursorStack.isEmpty()) {
+				if(pickUpSlotWithDelay(sourcePosition))
+					return;
+			}
+			if(pickUpSlotWithDelay(targetPosition))
+				return;
+		}
+
+		remainingSlots.remove(sourcePosition);
+		replaceSlot(remainingSlots, oldPosToNewPosMapping, targetPosition);
+	}
+
+	/**
+	 * Consumes a list of ordered slot positions and produces a mapping of their current positions to their new one
+	 *
+	 * @param orderedSlots value example: [0, 1, 5, 6, 11, 12, 13, 15, 16, 17, 20, 22, 23]
+	 * @return value example: {0=0, 1=1, 5=2, 6=3, 11=4, 12=5, 13=6, 15=7, 16=8, 17=9, 20=10, 22=11, 23=12}
+	 */
+	private Map<Integer, Integer> getOldPosToNewPosMapping(final List<Integer> orderedSlots) {
+		final Map<Integer, Integer> oldPosToNewPosMapping = new HashMap<>();
+		int counter = 0;
+
+		for(int slotNum : orderedSlots)
+		{
+			oldPosToNewPosMapping.put(slotNum, counter);
+			++counter;
+		}
+
+		return oldPosToNewPosMapping;
+	}
+
+	/**
+	 * Produces a list of ordered slot positions containing items, sorted by item names.
+	 *
+	 * @param from Lower slot position bound (included)
+	 * @param to Upper slot position bound (excluded)
+	 * @return list of ordered slots
+	 */
+	private List<Integer> getOrderedSlots(final int from, final int to)
+	{
+		Map<String, List<Integer>> slotMap = getItemNameToSlotPositionsMap(from, to);
+		List<Integer> orderedSlots = new LinkedList<>();
+
+		for(String itemName : slotMap.keySet())
+		{
+			final List<Integer> sameItemNameSlotPositions = slotMap.get(itemName);
+
+			for(int slot : sameItemNameSlotPositions)
+				orderedSlots.add(slot);
+		}
+
+		return orderedSlots;
+	}
+
+	/**
+	 *
+	 * @param from Lower slot position bound (included)
+	 * @param to Upper slot position bound (excluded)
+	 * @return map of slot positions, sorted by item names
+	 */
+	private Map<String, List<Integer>> getItemNameToSlotPositionsMap(final int from, final int to)
+	{
+		Map<String, List<Integer>> itemNameToSlotPositionsMap = new HashMap<>();
+		for(int i = from; i < to; ++i)
+		{
+			final Slot slot = handler.slots.get(i);
+
+			if(slot.getStack().isEmpty())
+				continue;
+
+			final String itemName = slot.getStack().getItem().getName().getString();
+
+			if(itemNameToSlotPositionsMap.containsKey(itemName))
+				itemNameToSlotPositionsMap.get(itemName).add(i);
+			else
+				itemNameToSlotPositionsMap.put(itemName, new LinkedList<>(List.of(i)));
+		}
+
+		return itemNameToSlotPositionsMap;
+	}
+
+	/**
+	 * Wrapper for pickup slot action with added delay and cancellation detection
+	 *
+	 * @param sourcePosition
+	 * @return
+	 */
+	private boolean pickUpSlotWithDelay(int sourcePosition) {
+		Slot oldSlot = handler.slots.get(sourcePosition);
+
+		waitForDelay();
+
+		if(mustCancelOperation(mode))
+			return true;
+
+		onMouseClick(oldSlot, oldSlot.id, 0, SlotActionType.PICKUP);
+		return false;
+	}
+
+	/**
+	 * The user chose a new action among the available ones (Sort, Steal, Sort), or closed the Container GUI.
+	 *
+	 * @param mode
+	 * @return
+	 */
+	private boolean mustCancelOperation(int mode) {
+		return this.mode != mode || client.currentScreen == null;
+	}
+
 }


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
I added a "Sort" button on the Container GUI, next to "Steal" and "Store".
When activating it, it swaps items one by one.
It uses the same underlying mechanisms as "Steal" and "Store".

I added it to the existing class implementing the `AutoStealHack`, but maybe it could be categorized elsewhere. Indeed, the Steal hack also allows to Store, and Steal, Store and Sort all belong to some kind of "Container/Inventory Utilities"

## Screenshots

Example 
Before:
![Screenshot from 2021-11-28 16-43-34](https://user-images.githubusercontent.com/45271239/143775300-7e45ec3e-e286-49f8-a0b2-fe6d4d942669.png)

After:
![Screenshot from 2021-11-28 16-44-14](https://user-images.githubusercontent.com/45271239/143775301-ff7e05a2-5b98-49ae-ad91-a35430fa326a.png)


As you can see, there is an issue though: the button overlaps with the Container title. I am not sure where else I could put the button 
