### PR TITLE
Add OneEntityFollow Mode in 

### DIFF
--- a/src/main/java/net/wurstclient/events/LeftClickListener.java
+++ b/src/main/java/net/wurstclient/events/LeftClickListener.java
@@ -11,14 +11,25 @@ import java.util.ArrayList;
 
 import net.wurstclient.event.CancellableEvent;
 import net.wurstclient.event.Listener;
+import net.minecraft.entity.Entity;
 
 public interface LeftClickListener extends Listener
 {
 	public void onLeftClick(LeftClickEvent event);
 	
-	public static class LeftClickEvent
-		extends CancellableEvent<LeftClickListener>
+	public static class LeftClickEvent extends CancellableEvent<LeftClickListener>
 	{
+		private Entity entity;
+		public LeftClickEvent(Entity entity)
+		{
+			this.entity = entity;
+		}
+		
+		public getEntity()
+		{
+			return this.entity;
+		}
+		
 		@Override
 		public void fire(ArrayList<LeftClickListener> listeners)
 		{

--- a/src/main/java/net/wurstclient/hacks/KillauraLegitHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraLegitHack.java
@@ -112,8 +112,11 @@ public final class KillauraLegitHack extends Hack
 		"Filter armor stands", "Won't attack armor stands.", false);
 	private final CheckboxSetting filterCrystals = new CheckboxSetting(
 		"Filter end crystals", "Won't attack end crystals.", false);
+	private final CheckboxSetting followMode = new CheckboxSetting(
+		"Hits only the selected player (Choice by blow)", false);
 	
 	private Entity target;
+	public Entity followEntity;
 	
 	public KillauraLegitHack()
 	{
@@ -245,7 +248,8 @@ public final class KillauraLegitHack extends Hack
 		if(filterCrystals.isChecked())
 			stream = stream.filter(e -> !(e instanceof EndCrystalEntity));
 		
-		target = stream.min(priority.getSelected().comparator).orElse(null);
+		if(followMode.isChecked()) target = followEntity;
+		else target = stream.min(priority.getSelected().comparator).orElse(null);
 		if(target == null)
 			return;
 		

--- a/src/main/java/net/wurstclient/hacks/KillauraLegitHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraLegitHack.java
@@ -139,6 +139,7 @@ public final class KillauraLegitHack extends Hack
 		addSetting(filterNamed);
 		addSetting(filterStands);
 		addSetting(filterCrystals);
+		addSetting(followMode);
 	}
 	
 	@Override
@@ -156,6 +157,7 @@ public final class KillauraLegitHack extends Hack
 		
 		EVENTS.add(UpdateListener.class, this);
 		EVENTS.add(RenderListener.class, this);
+		EVENTS.add(LeftClickEvent.class, this);
 	}
 	
 	@Override
@@ -163,7 +165,8 @@ public final class KillauraLegitHack extends Hack
 	{
 		EVENTS.remove(UpdateListener.class, this);
 		EVENTS.remove(RenderListener.class, this);
-		target = null;
+		EVENTS.remove(LeftClickEvent.class, this);
+		target = followEntity = null;		
 	}
 	
 	@Override


### PR DESCRIPTION
I tried to add OneEntityFollow mode to KillAuraLegit, how it works:
When a player clicks on an entity with the left mouse button, he starts hitting only that entity.
I already did this in my personal cheat (API near forge)
But I still did not understand how to implement this in Wurst
Here's the code to understand:

----------EventEntityLeftClick.java----------
public void entityLeftClick(EntityLeftClick e){
KillauraLegit.followEntity = e.getEntity(); 
}

----------KillauraLegit----------
public void Update(){
 if(Math.abs(Math.abs(a.followEntity.getX()) - Math.abs(a.player.getX())) + Math.abs(Math.abs(a.followEntity.getZ()) - Math.abs(a.player.getZ())) < speed && Math.abs(a.followEntity.getY() - a.player.getY())< 13) {
    float yaw = (float)V3D.getAngle(a.player.getX(), a.player.getZ(), a.followEntity.getX(), a.followEntity.getZ());
    float pit = (float)V3D.getPitch(a.player.getX(), a.player.getY(), a.player.getZ(), a.followEntity.getX(), a.followEntity.getY(), a.followEntity.getZ());
    if(yaw >= 0 && yaw <= 360) a.player.setYaw(yaw);
    if(pit >= -360 && pit <= 360) a.player.setPitch(pit);
  }
}
