### PR TITLE
ModMenu integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+	maven {
+		name = "TerraformersMC"
+		url = "https://maven.terraformersmc.com/releases/"
+	}
 }
 
 dependencies {
@@ -33,7 +37,8 @@ dependencies {
 	//
 	// In other words, Wurst won't compile without this library,
 	// even though it's Minecraft that actually uses it.
-	modImplementation 'com.google.code.findbugs:jsr305:3.0.2'
+	implementation 'com.google.code.findbugs:jsr305:3.0.2' //This is NOT a mod
+	modImplementation 'com.terraformersmc:modmenu:3.0.1'
 }
 
 processResources {

--- a/src/main/java/net/wurstclient/WurstModMenuRegistry.java
+++ b/src/main/java/net/wurstclient/WurstModMenuRegistry.java
@@ -1,0 +1,13 @@
+package net.wurstclient;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import net.minecraft.client.gui.screen.Screen;
+import net.wurstclient.options.WurstOptionsScreen;
+
+public class WurstModMenuRegistry implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return (ConfigScreenFactory<Screen>) WurstOptionsScreen::new;
+    }
+}

--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -7,6 +7,7 @@
  */
 package net.wurstclient.mixin;
 
+import net.fabricmc.loader.api.FabricLoader;
 import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,23 +29,33 @@ import net.wurstclient.WurstClient;
 import net.wurstclient.mixinterface.IScreen;
 import net.wurstclient.options.WurstOptionsScreen;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 @Mixin(GameMenuScreen.class)
 public abstract class GameMenuScreenMixin extends Screen
 {
 	private static final Identifier wurstTexture =
 		new Identifier("wurst", "wurst_128.png");
-	
+	private AtomicBoolean isModMenuPresent;
+
 	private ButtonWidget wurstOptionsButton;
 	
 	private GameMenuScreenMixin(WurstClient wurst, Text text_1)
 	{
 		super(text_1);
 	}
+
+	private boolean isModMenu(){
+		if(isModMenuPresent == null){
+			isModMenuPresent = new AtomicBoolean(FabricLoader.getInstance().isModLoaded("modmenu"));
+		}
+		return isModMenuPresent.get();
+	}
 	
 	@Inject(at = {@At("TAIL")}, method = {"initWidgets()V"})
 	private void onInitWidgets(CallbackInfo ci)
 	{
-		if(!WurstClient.INSTANCE.isEnabled())
+		if(!WurstClient.INSTANCE.isEnabled() || isModMenu())
 			return;
 		
 		addWurstOptionsButton();
@@ -90,7 +101,7 @@ public abstract class GameMenuScreenMixin extends Screen
 	private void onRender(MatrixStack matrixStack, int mouseX, int mouseY,
 		float partialTicks, CallbackInfo ci)
 	{
-		if(!WurstClient.INSTANCE.isEnabled())
+		if(!WurstClient.INSTANCE.isEnabled() || isModMenu())
 			return;
 		
 		GL11.glEnable(GL11.GL_CULL_FACE);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,7 +20,8 @@
   "entrypoints": {
     "main": [
       "net.wurstclient.WurstInitializer"
-    ]
+    ],
+    "modmenu": [ "net.wurstclient.WurstModMenuRegistry" ]
   },
   "mixins": [
     "wurst.mixins.json"


### PR DESCRIPTION
## Description
Wurst disabled the in-game ModMenu option, making it unusable...  
1. Register Wurst config screen into ModMenu
2. If ModMenu is installed, do not display Wurst option, The menu is still accessible via ModMenu  

If ModMenu is not installed, the config option is displayed.

