### PR TITLE
Add stale issue checker

### DIFF
--- a/.github/actions/stale.yaml
+++ b/.github/actions/stale.yaml
@@ -1,0 +1,20 @@
+name: "Close stale issues / pull requests"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: |
+            This issue has been open for a while. It will be closed soon if nobody comments on it.  
+            Issues should be closed if:
+              - They are duplicates of other issues
+              - There is not enough demand
+              - They are no longer relevant
+              - There are not enough details
+          days-before-stale: 30
+          days-before-close: 30


### PR DESCRIPTION
## Description
Added a GitHub Actions stale issue checker. If an issue has had no comments for a month, it will automatically comment:
> This issue has been open for a while. It will be closed soon if nobody comments on it.  
> Issues should be closed if:
>  - They are duplicates of other issues
>  - There is not enough demand
>  - They are no longer relevant
>  - There are not enough details

If after that message is automatically commented, there are no comments for another month, the issue will be closed. This should help cut down on the number of issues.

CC @Alexander01998 