### PR TITLE
TradeFill Feature

### DIFF
--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -160,6 +160,7 @@ public final class HackList implements UpdateListener
 	public final TiredHack tiredHack = new TiredHack();
 	public final TooManyHaxHack tooManyHaxHack = new TooManyHaxHack();
 	public final TpAuraHack tpAuraHack = new TpAuraHack();
+	public final TradeFillHack tradeFillHack = new TradeFillHack();
 	public final TrajectoriesHack trajectoriesHack = new TrajectoriesHack();
 	public final TreeBotHack treeBotHack = new TreeBotHack();
 	public final TriggerBotHack triggerBotHack = new TriggerBotHack();

--- a/src/main/java/net/wurstclient/hacks/TradeFillHack.java
+++ b/src/main/java/net/wurstclient/hacks/TradeFillHack.java
@@ -37,5 +37,6 @@ public class TradeFillHack extends Hack implements UpdateListener {
 	@Override
 	public void onUpdate() {
 		if (nextTick != null) nextTick.run();
+		nextTick = null;
 	}
 }

--- a/src/main/java/net/wurstclient/hacks/TradeFillHack.java
+++ b/src/main/java/net/wurstclient/hacks/TradeFillHack.java
@@ -1,0 +1,41 @@
+/**
+ * 
+ */
+package net.wurstclient.hacks;
+
+import net.wurstclient.SearchTags;
+import net.wurstclient.events.UpdateListener;
+import net.wurstclient.hack.Hack;
+
+/**
+ * @author yuanlu
+ *
+ */
+@SearchTags({ "auto", "autotradefill", "villager" })
+public class TradeFillHack extends Hack implements UpdateListener {
+
+	public TradeFillHack() {
+		super("TradeFill");
+	}
+
+	private Runnable nextTick;
+
+	public void nextTick(Runnable runnable) {
+		nextTick = runnable;
+	}
+
+	@Override
+	protected void onEnable() {
+		EVENTS.add(UpdateListener.class, this);
+	}
+
+	@Override
+	protected void onDisable() {
+		EVENTS.remove(UpdateListener.class, this);
+	}
+
+	@Override
+	public void onUpdate() {
+		if (nextTick != null) nextTick.run();
+	}
+}

--- a/src/main/java/net/wurstclient/mixin/MerchantScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MerchantScreenMixin.java
@@ -1,0 +1,58 @@
+/**
+ * 
+ */
+package net.wurstclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.MerchantScreen;
+import net.minecraft.client.gui.screen.ingame.ScreenHandlerProvider;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.network.packet.c2s.play.SelectMerchantTradeC2SPacket;
+import net.minecraft.screen.MerchantScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.text.Text;
+import net.wurstclient.WurstClient;
+import net.wurstclient.hacks.TradeFillHack;
+
+/**
+ * villager
+ * 
+ * @author yuanlu
+ *
+ */
+@Mixin(MerchantScreen.class)
+public abstract class MerchantScreenMixin 
+extends HandledScreen<MerchantScreenHandler>
+implements ScreenHandlerProvider<MerchantScreenHandler>{
+
+	public MerchantScreenMixin(WurstClient wurst,
+			MerchantScreenHandler container,
+		PlayerInventory playerInventory, Text name)
+	{
+		super(container, playerInventory, name);
+	}
+	
+	@Shadow
+	private int selectedIndex;
+
+	private final TradeFillHack tradeFill =
+		WurstClient.INSTANCE.getHax().tradeFillHack;
+	
+	@Override
+	protected void onMouseClick(Slot slot, int slotId, int button, SlotActionType actionType) {
+		super.onMouseClick(slot, slotId, button, actionType);
+		
+		if (tradeFill.isEnabled())tradeFill.nextTick(this::fillTrade);
+		
+	}
+	
+	private void fillTrade() {
+		var handler = ((MerchantScreenHandler) super.handler);
+		handler.switchTo(this.selectedIndex);
+        this.client.getNetworkHandler().sendPacket(new SelectMerchantTradeC2SPacket(this.selectedIndex));
+	}
+}

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -129,6 +129,7 @@
   "description.wurst.hack.tired": "Makes you look like Alexander back in April 2015.\nOnly visible to other players.",
   "description.wurst.hack.toomanyhax": "Blocks any features that you don't want.\nAllows you to make sure that you don't accidentally enable the wrong hack and get banned for it.\nFor those who want to \"only hack a little bit\".\n\nUse the §6.toomanyhax§r command to choose which features to block.\nType §6.help toomanyhax§r for more info.",
   "description.wurst.hack.tp-aura": "Automatically attacks the closest valid entity while teleporting around it.",
+  "description.wurst.hack.tradefill": "Automatically fill merchant items\nNeed click the desired recipe in the trade list at first.",
   "description.wurst.hack.trajectories": "Predicts the flight path of arrows and throwable items.",
   "description.wurst.hack.treebot": "An experimental bot that automatically walks around and chops down trees.\nLimited to small trees for now.",
   "description.wurst.hack.triggerbot": "Automatically attacks the entity you're looking at.",

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -129,7 +129,7 @@
   "description.wurst.hack.tired": "Makes you look like Alexander back in April 2015.\nOnly visible to other players.",
   "description.wurst.hack.toomanyhax": "Blocks any features that you don't want.\nAllows you to make sure that you don't accidentally enable the wrong hack and get banned for it.\nFor those who want to \"only hack a little bit\".\n\nUse the §6.toomanyhax§r command to choose which features to block.\nType §6.help toomanyhax§r for more info.",
   "description.wurst.hack.tp-aura": "Automatically attacks the closest valid entity while teleporting around it.",
-  "description.wurst.hack.tradefill": "Automatically fill merchant items\nNeed click the desired recipe in the trade list at first.",
+  "description.wurst.hack.tradefill": "Automatically inserts emeralds into the villager trade menu.\nNeed click the desired recipe in the trade list at first.",
   "description.wurst.hack.trajectories": "Predicts the flight path of arrows and throwable items.",
   "description.wurst.hack.treebot": "An experimental bot that automatically walks around and chops down trees.\nLimited to small trees for now.",
   "description.wurst.hack.triggerbot": "Automatically attacks the entity you're looking at.",

--- a/src/main/resources/assets/wurst/lang/zh_cn.json
+++ b/src/main/resources/assets/wurst/lang/zh_cn.json
@@ -129,6 +129,7 @@
   "description.wurst.hack.tired": "让你看起来很像 Alexander 回到 4月 2015年。\n仅限其他玩家可视。",
   "description.wurst.hack.toomanyhax": "屏蔽那些你并不想要有的功能。\n让你确保你不会不小心开启错误的作弊功能导致被服务器封禁。\n这个是给那些 “只想作弊一点点的用户”。\n\n使用指令 §6.toomanyhax§r 来选择哪些功能需要被屏蔽。\n输入 §6.help toomanyhax§r 寻求更多。",
   "description.wurst.hack.tp-aura": "自动传送到实体附近并自动攻击他。",
+  "description.wurst.hack.tradefill": "自动填充村民交易界面的原材料。\n需要先点击左侧交易列表中所需的配方。",
   "description.wurst.hack.trajectories": "预测箭和投掷物品的飞行路径。",
   "description.wurst.hack.treebot": "一个实验性的机器人将会在树木附近砍树。\n目前仅限于砍小树。",
   "description.wurst.hack.triggerbot": "自动攻击你所看的实体。",

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -39,6 +39,7 @@
     "KeyboardMixin",
     "LanguageManagerMixin",
     "LivingEntityRendererMixin",
+	"MerchantScreenMixin",
     "MinecraftClientMixin",
     "MiningToolItemMixin",
     "MouseMixin",


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

## Description
**An automatic Feature: automatically fill in items traded with villagers**
Using this feature, players can select the content to be automatically filled by clicking the transaction item on the left side of the transaction page. You only need to take the items in exchange. This feature will automatically fill in the supplied items.


## (Optional) screenshots / videos

https://user-images.githubusercontent.com/38997444/149381176-972f52d9-b1de-4a50-bec1-73d631a9fd99.mp4


