### PR TITLE
Fix injection of Wurst options button

### DIFF
--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -15,17 +15,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
+import java.util.List;
+
+import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.ClickableWidget;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.wurstclient.WurstClient;
-import net.wurstclient.mixinterface.IScreen;
 import net.wurstclient.options.WurstOptionsScreen;
 
 @Mixin(GameMenuScreen.class)
@@ -48,41 +50,45 @@ public abstract class GameMenuScreenMixin extends Screen
 			return;
 		
 		addWurstOptionsButton();
-		removeFeedbackAndBugReportButtons();
 	}
 	
 	private void addWurstOptionsButton()
 	{
-		wurstOptionsButton = new ButtonWidget(width / 2 - 102, height / 4 + 56,
-			204, 20, new LiteralText("            Options"),
-			b -> openWurstOptions());
+		List<ClickableWidget> buttons = Screens.getButtons(this);
 		
-		addDrawableChild(wurstOptionsButton);
+		int buttonWidth = 204;
+		int buttonHeight = 20;
+		
+		int buttonX = this.width / 2 - 102;
+		int buttonY = 0;
+		
+		int idx = 0;
+		
+		for (int i = 0; i < buttons.size(); ++i)
+		{
+			ClickableWidget button = buttons.get(i);
+			
+			// insert Wurst button in place of game options row
+			if (button.visible && buttonHasText(button, "menu.options"))
+			{
+				buttonY = button.y;
+				idx = i;
+			}
+			
+			// shift next buttons down
+			if (buttonY != 0)
+			{
+				button.y += buttonHeight + 4;
+			}
+		}
+		
+		wurstOptionsButton = new ButtonWidget(buttonX, buttonY, buttonWidth, buttonHeight, new LiteralText("            Options"), b -> openWurstOptions());
+		buttons.add(idx, wurstOptionsButton);
 	}
 	
 	private void openWurstOptions()
 	{
 		client.setScreen(new WurstOptionsScreen(this));
-	}
-	
-	private void removeFeedbackAndBugReportButtons()
-	{
-		((IScreen)this).getButtons()
-			.removeIf(this::isFeedbackOrBugReportButton);
-		children().removeIf(this::isFeedbackOrBugReportButton);
-	}
-	
-	private boolean isFeedbackOrBugReportButton(Object element)
-	{
-		if(element == null || !(element instanceof ClickableWidget))
-			return false;
-		
-		ClickableWidget button = (ClickableWidget)element;
-		String message = button.getMessage().getString();
-		
-		return message != null
-			&& (message.equals(I18n.translate("menu.sendFeedback"))
-				|| message.equals(I18n.translate("menu.reportBugs")));
 	}
 	
 	@Inject(at = {@At("TAIL")},
@@ -111,5 +117,11 @@ public abstract class GameMenuScreenMixin extends Screen
 		float u = 0;
 		float v = 0;
 		drawTexture(matrixStack, x, y, u, v, w, h, fw, fh);
+	}
+	
+	private static boolean buttonHasText(ClickableWidget button, String translationKey)
+	{
+		Text text = button.getMessage();
+		return text instanceof TranslatableText && ((TranslatableText) text).getKey().equals(translationKey);
 	}
 }


### PR DESCRIPTION
Fix injection of Wurst options button so it doesn't interfere with such mods as ModMenu (fixes https://github.com/Wurst-Imperium/Wurst7/issues/546).

Now it looks for `menu.options` button (vanilla options), inserts Wurst options here and shifts all next buttons down.

Also uses `Screens.getButtons` instead of direct `addDrawableChild` call so game screen maintains correct order of child widgets and other mods can also inject their buttons without interfering with Wurst button (given they do it properly). 

Result:
**ModMenu installed**
![2022-01-19-21-19-55-947_java](https://user-images.githubusercontent.com/63540878/150191819-abe48248-4a1d-45a7-b9b8-5785d64d0378.png)

**Without ModMenu**
![2022-01-19-21-20-52-926_java](https://user-images.githubusercontent.com/63540878/150191835-c9b4ea47-20a4-4bc6-85df-d2714b55347c.png)

