### PR TITLE
Update new translation of zh_tw

### DIFF
--- a/src/main/resources/assets/wurst/lang/zh_tw.json
+++ b/src/main/resources/assets/wurst/lang/zh_tw.json
@@ -145,5 +145,9 @@
   "description.wurst.altmanager.favorite": "你標記了這其中一個帳戶為你的喜愛。",
   "description.wurst.altmanager.window": "這個按鈕是打開另一個視窗的。",
   "description.wurst.altmanager.window_freeze": "當打開另一個視窗時，這會導致遊戲看起來未響應。",
-  "description.wurst.altmanager.fullscreen": "§c請關閉全屏模式！"
+  "description.wurst.altmanager.fullscreen": "§c請關閉全屏模式！",
+  "gui.wurst.altmanager.folder_error.title": "無法創建 “.Wurst encryption” 文件夾。",
+  "gui.wurst.altmanager.folder_error.message": "你可能在無意中阻止了 Wurst 訪問這個文件夾。\nAltManager 無法在沒有權限的情況下加密或解密 Alt List。\n你可以繼續使用 AltManager，但是你新建的 Alt 都無法被存儲。\n\n完整的錯誤信息如下：\n%s",
+  "gui.wurst.altmanager.empty.title": "你的 Alt List 是空的。",
+  "gui.wurst.altmanager.empty.message": "你希望 Wurst 生成一些離綫賬戶嗎？"
 }


### PR DESCRIPTION
update zh_tw

Should i change following (I'll keep the original words for now): （我是否要修改以下幾點，當前暫時保留原詞）
"AltManager" to "賬號管理器"(Account Manager)
"Alt" to “賬號”(Account)
"Alt List" to "賬號列表"(Account list)

Because the function of it is manage account and "ALT" it self is the account or cracked account（因爲ALT這個詞本身就是賬戶相關的，如果保留會對高級用戶和其他語言用戶的交流更加友好，如果修改爲“賬號”類的，新手更加易懂）
