### PR TITLE
🪲 Don't trigger keybinds if we're trying to use an F3 debug command

### DIFF
--- a/src/main/java/net/wurstclient/keybinds/KeybindProcessor.java
+++ b/src/main/java/net/wurstclient/keybinds/KeybindProcessor.java
@@ -39,6 +39,8 @@ public final class KeybindProcessor implements KeyPressListener
 		if(event.getAction() != GLFW.GLFW_PRESS)
 			return;
 		
+		if (InputUtil.isKeyPressed(WurstClient.MC.getWindow().getHandle(), GLFW.GLFW_KEY_F3)) return;
+
 		Screen screen = WurstClient.MC.currentScreen;
 		if(screen != null && !(screen instanceof ClickGuiScreen))
 			return;


### PR DESCRIPTION
This change fixes an issue where trying to use a debug key combo (e.g. F3+B to show hitboxes, or F3+G to show chunk boundaries) would also trigger any keybinds tied to those keys (in the previous example, it would trigger FastBreak/Place or Flight respectively with default keybinds)