### PR TITLE
🪲 Fix NoBackground breaking menus outside of gameplay

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ScreenMixin.java
@@ -54,7 +54,7 @@ public abstract class ScreenMixin extends AbstractParentElement
 		cancellable = true)
 	public void onRenderBackground(MatrixStack matrices, CallbackInfo ci)
 	{
-		if(WurstClient.INSTANCE.getHax().noBackgroundHack.isEnabled())
+		if(WurstClient.INSTANCE.getHax().noBackgroundHack.isEnabled() && WurstClient.MC.world != null)
 			ci.cancel();
 	}
 	


### PR DESCRIPTION
This adds a simple check to only enforce NoBackground while actively loaded into a world, preventing this from happening:

![Screenshot_20220407_171320](https://user-images.githubusercontent.com/3847441/162317966-a5c3fa65-a0a9-4add-b5db-fb6a676260c2.png)
