### PR TITLE
Add NoBlockOverlay

### DIFF
--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -121,6 +121,8 @@ public final class HackList implements UpdateListener
 	public final NavigatorHack navigatorHack = new NavigatorHack();
 	public final NewChunksHack newChunksHack = new NewChunksHack();
 	public final NoBackgroundHack noBackgroundHack = new NoBackgroundHack();
+	public final NoBlockOverlayHack noBlockOverlayHack =
+		new NoBlockOverlayHack();
 	public final NoClipHack noClipHack = new NoClipHack();
 	public final NoFallHack noFallHack = new NoFallHack();
 	public final NoFireOverlayHack noFireOverlayHack = new NoFireOverlayHack();

--- a/src/main/java/net/wurstclient/hacks/NoBlockOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoBlockOverlayHack.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014-2022 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.hacks;
+
+import net.wurstclient.Category;
+import net.wurstclient.SearchTags;
+import net.wurstclient.hack.Hack;
+
+@SearchTags({"NoSuffocationOverlay", "no suffocation overlay",
+	"no block overlay"})
+public final class NoBlockOverlayHack extends Hack
+{
+	public NoBlockOverlayHack()
+	{
+		super("NoBlockOverlay");
+		setCategory(Category.RENDER);
+	}
+}

--- a/src/main/java/net/wurstclient/hacks/NoBlockOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoBlockOverlayHack.java
@@ -20,4 +20,6 @@ public final class NoBlockOverlayHack extends Hack
 		super("NoBlockOverlay");
 		setCategory(Category.RENDER);
 	}
+	
+	// See InGameOverlayRendererMixin.onRenderInWallOverlay()
 }

--- a/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
@@ -42,4 +42,13 @@ public class InGameOverlayRendererMixin
 		if(WurstClient.INSTANCE.getHax().noOverlayHack.isEnabled())
 			ci.cancel();
 	}
+	
+	@Inject(at = @At("HEAD"),
+		method = "renderInWallOverlay(Lnet/minecraft/client/texture/Sprite;Lnet/minecraft/client/util/math/MatrixStack;)V",
+		cancellable = true)
+	private static void onRenderInWallOverlay(CallbackInfo ci)
+	{
+		if(WurstClient.INSTANCE.getHax().noBlockOverlayHack.isEnabled())
+			ci.cancel();
+	}
 }

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -103,6 +103,7 @@
   "description.wurst.hack.navigator": "A searchable GUI that learns your preferences over time.",
   "description.wurst.hack.newchunks": "Highlights newly generated chunks around you.",
   "description.wurst.hack.nobackground": "Removes the dark background behind inventories.",
+  "description.wurst.hack.noblockoverlay": "Blocks the overlay when you are suffocating in a block.",
   "description.wurst.hack.noclip": "Allows you to freely move through blocks.\nA block (e.g. sand) must fall on your head to activate it.\n\n§c§lWARNING:§r You will take damage while moving through blocks!",
   "description.wurst.hack.nocomcrash": "Lags and crashes servers using the Nocom exploit.\nDoes not work on Paper servers. Tested working on Vanilla, Spigot, and Fabric. Can be disabled by some AntiCheats.",
   "description.wurst.hack.nofall": "Protects you from fall damage.",


### PR DESCRIPTION
This PR adds a hack called "NoBlockOverlay". This hack simply removes the overlay when you are suffocating in a block.