### PR TITLE
Added Translation Keys for 'key.wurst.zoom' in all lang files

### DIFF
--- a/src/main/resources/assets/wurst/lang/cs_cz.json
+++ b/src/main/resources/assets/wurst/lang/cs_cz.json
@@ -171,5 +171,6 @@
   "gui.wurst.nochatreports.ncr_mod_server.title": "Server \"No Chat Reports\"",
   "button.wurst.nochatreports.signatures_status": "Podpisy: ",
   "gui.wurst.generic.allcaps_blocked": "BLOKOVÁNO",
-  "gui.wurst.generic.allcaps_allowed": "POVOLENO"
+  "gui.wurst.generic.allcaps_allowed": "POVOLENO",
+  "key.wurst.zoom": "Tlačítko Zoom"
 }

--- a/src/main/resources/assets/wurst/lang/de_de.json
+++ b/src/main/resources/assets/wurst/lang/de_de.json
@@ -134,5 +134,6 @@
   "button.wurst.nochatreports.signatures_status": "Signaturen: ",
   "description.wurst.nochatreports.message_is_reportable": "Diese Nachricht hat eine gültige Signatur und kann daher für betrügerische Chat-Reports missbraucht werden.",
   "gui.wurst.generic.allcaps_blocked": "BLOCKIERT",
-  "gui.wurst.generic.allcaps_allowed": "ERLAUBT"
+  "gui.wurst.generic.allcaps_allowed": "ERLAUBT",
+  "key.wurst.zoom": "Zoom Taste"
 }

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -185,5 +185,6 @@
   "button.wurst.nochatreports.signatures_status": "Signatures: ",
   "description.wurst.nochatreports.message_is_reportable": "This message has a valid signature and is thus vulnerable to fraudulent chat reports.",
   "gui.wurst.generic.allcaps_blocked": "BLOCKED",
-  "gui.wurst.generic.allcaps_allowed": "ALLOWED"
+  "gui.wurst.generic.allcaps_allowed": "ALLOWED",
+  "key.wurst.zoom": "Zoom Key"
 }

--- a/src/main/resources/assets/wurst/lang/fr_fr.json
+++ b/src/main/resources/assets/wurst/lang/fr_fr.json
@@ -181,5 +181,6 @@
   "button.wurst.nochatreports.signatures_status": "Signatures: ",
   "description.wurst.nochatreports.message_is_reportable": "Ce message a une signature valide et est donc vulnérable aux signalements de chat frauduleux.",
   "gui.wurst.generic.allcaps_blocked": "BLOQUÉ",
-  "gui.wurst.generic.allcaps_allowed": "AUTORISÉ"
+  "gui.wurst.generic.allcaps_allowed": "AUTORISÉ",
+  "key.wurst.zoom": "Touche Zoom"
 }

--- a/src/main/resources/assets/wurst/lang/it_it.json
+++ b/src/main/resources/assets/wurst/lang/it_it.json
@@ -182,5 +182,6 @@
   "button.wurst.nochatreports.signatures_status": "Firme: ",
   "description.wurst.nochatreports.message_is_reportable": "Questo messaggio ha una firma valida ed è quindi vulnerabile ai chat reports.",
   "gui.wurst.generic.allcaps_blocked": "BLOCCATO",
-  "gui.wurst.generic.allcaps_allowed": "PERMESSO"
+  "gui.wurst.generic.allcaps_allowed": "PERMESSO",
+  "key.wurst.zoom": "Tasto Zoom"
 }

--- a/src/main/resources/assets/wurst/lang/ja_jp.json
+++ b/src/main/resources/assets/wurst/lang/ja_jp.json
@@ -181,5 +181,6 @@
   "button.wurst.nochatreports.signatures_status": "署名: ",
   "description.wurst.nochatreports.message_is_reportable": "このメッセージには有効な署名があるため、不正なチャット レポートに対して脆弱です。",
   "gui.wurst.generic.allcaps_blocked": "ブロックされました",
-  "gui.wurst.generic.allcaps_allowed": "許可された"
+  "gui.wurst.generic.allcaps_allowed": "許可された",
+  "key.wurst.zoom": "ズームキー"
 }

--- a/src/main/resources/assets/wurst/lang/pl_pl.json
+++ b/src/main/resources/assets/wurst/lang/pl_pl.json
@@ -181,5 +181,6 @@
   "button.wurst.nochatreports.signatures_status": "Sygnatury: ",
   "description.wurst.nochatreports.message_is_reportable": "Ta wiadomość ma prawidłową sygnaturę, przez co jest podatna na fałszywe zgłoszenia.",
   "gui.wurst.generic.allcaps_blocked": "ZABLOKOWANE",
-  "gui.wurst.generic.allcaps_allowed": "DOZWOLONE"
+  "gui.wurst.generic.allcaps_allowed": "DOZWOLONE",
+  "key.wurst.zoom": "Klawisz powiększenia"
 }

--- a/src/main/resources/assets/wurst/lang/ro_ro.json
+++ b/src/main/resources/assets/wurst/lang/ro_ro.json
@@ -176,5 +176,6 @@
   "button.wurst.nochatreports.signatures_status": "Semnături: ",
   "description.wurst.nochatreports.message_is_reportable": "Acest mesaj are o semnătura valida si prin urmare este vulnerabil la rapoarte de chat.",
   "gui.wurst.generic.allcaps_blocked": "BLOCAT",
-  "gui.wurst.generic.allcaps_allowed": "PERMIS"
+  "gui.wurst.generic.allcaps_allowed": "PERMIS",
+  "key.wurst.zoom": "Tasta Zoom"
 }

--- a/src/main/resources/assets/wurst/lang/ru_ru.json
+++ b/src/main/resources/assets/wurst/lang/ru_ru.json
@@ -181,5 +181,6 @@
   "button.wurst.nochatreports.signatures_status": "Подписи: ",
   "description.wurst.nochatreports.message_is_reportable": "Это сообщение имеет действительную подпись и поэтому уязвимо для заведомо ложных чат-репортов.",
   "gui.wurst.generic.allcaps_blocked": "ЗАБЛОКИРОВАНО",
-  "gui.wurst.generic.allcaps_allowed": "РАЗРЕШЕНО"
+  "gui.wurst.generic.allcaps_allowed": "РАЗРЕШЕНО",
+  "key.wurst.zoom": "Клавиша масштабирования"
 }

--- a/src/main/resources/assets/wurst/lang/uk_ua.json
+++ b/src/main/resources/assets/wurst/lang/uk_ua.json
@@ -181,5 +181,6 @@
   "button.wurst.nochatreports.signatures_status": "Підписи: ",
   "description.wurst.nochatreports.message_is_reportable": "Це повідомлення має дійсний підпис і тому вразливе для шахрайських звітів чату.",
   "gui.wurst.generic.allcaps_blocked": "ЗАБЛОКОВАНО",
-  "gui.wurst.generic.allcaps_allowed": "ДОЗВОЛЕНО"
+  "gui.wurst.generic.allcaps_allowed": "ДОЗВОЛЕНО",
+  "key.wurst.zoom": "Клавіша масштабування"
 }

--- a/src/main/resources/assets/wurst/lang/zh_cn.json
+++ b/src/main/resources/assets/wurst/lang/zh_cn.json
@@ -185,5 +185,6 @@
   "button.wurst.nochatreports.signatures_status": "签名: ",
   "description.wurst.nochatreports.message_is_reportable": "此消息有一个有效的签名，因此容易受到欺诈性聊天报告的伤害。",
   "gui.wurst.generic.allcaps_blocked": "黑名单",
-  "gui.wurst.generic.allcaps_allowed": "已允许"
+  "gui.wurst.generic.allcaps_allowed": "已允许",
+  "key.wurst.zoom": "缩放键"
 }

--- a/src/main/resources/assets/wurst/lang/zh_hk.json
+++ b/src/main/resources/assets/wurst/lang/zh_hk.json
@@ -166,5 +166,6 @@
   "gui.wurst.altmanager.folder_error.title": "無法創建 「.Wurst encryption」 文件夾！",
   "gui.wurst.altmanager.folder_error.message": "你可能唔小心阻止 Wurst 訪問呢個文件夾。\n如果Wurst無法訪問， AltManager 將無法加密或解密你嘅帳號列表。\n你依然可以使用 AltManager，但你依家創建嘅任何帳號將冇辦法被保存。\n\n全部錯誤如下：\n%s",
   "gui.wurst.altmanager.empty.title": "你嘅帳號列表係空嘅。",
-  "gui.wurst.altmanager.empty.message": "你想唔想要啲隨機嘅帳號嚟開始？"
+  "gui.wurst.altmanager.empty.message": "你想唔想要啲隨機嘅帳號嚟開始？",
+  "key.wurst.zoom": "縮放鍵"
 }

--- a/src/main/resources/assets/wurst/lang/zh_tw.json
+++ b/src/main/resources/assets/wurst/lang/zh_tw.json
@@ -181,5 +181,6 @@
   "button.wurst.nochatreports.signatures_status": "簽名： ",
   "description.wurst.nochatreports.message_is_reportable": "此訊息具有有效簽名，因此容易受到欺詐性聊天檢舉的攻擊。",
   "gui.wurst.generic.allcaps_blocked": "封鎖",
-  "gui.wurst.generic.allcaps_allowed": "允許"
+  "gui.wurst.generic.allcaps_allowed": "允許",
+  "key.wurst.zoom": "縮放鍵"
 }


### PR DESCRIPTION
Everything except EN, DE, and PL is translated with Google Translator, but they should be fine for such a short string. Why did I do this? It kind of annoyed me that the translation key wasn't set :)
