### PR TITLE
Option to lower fire overlay

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
@@ -10,38 +10,27 @@ package net.wurstclient.hacks;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
-import net.wurstclient.settings.EnumSetting;
+import net.wurstclient.settings.SliderSetting;
+import net.wurstclient.settings.SliderSetting.ValueDisplay;
 
 @SearchTags({"no fire overlay"})
 public final class NoFireOverlayHack extends Hack
 {
-	private final EnumSetting<Mode> mode = new EnumSetting<>("Mode",
-		"\u00a7lLower\u00a7r mode lowers the overlay.\n"
-			+ "\u00a7lRemove\u00a7r mode removes the overlay.",
-		Mode.values(), Mode.REMOVE);
+	private final SliderSetting offset =
+		new SliderSetting("Offset", "The amount to lower the fire overlay by.",
+			0.6, 0, 0.6, 0.01, ValueDisplay.DECIMAL);
 	
 	public NoFireOverlayHack()
 	{
 		super("NoFireOverlay");
 		setCategory(Category.RENDER);
-		addSetting(mode);
+		addSetting(offset);
 	}
 	
-	public boolean shouldCancelOverlay()
+	public float getOverlayOffset()
 	{
-		return isEnabled() && mode.getSelected() == Mode.REMOVE;
+		return isEnabled() ? offset.getValueF() : 0;
 	}
 	
-	public boolean shouldLowerOverlay()
-	{
-		return isEnabled() && mode.getSelected() == Mode.LOWER;
-	}
-	
-	private enum Mode
-	{
-		LOWER,
-		REMOVE;
-	}
-	
-	// See InGameOverlayRendererMixin.onRenderFireOverlay()
+	// See InGameOverlayRendererMixin.getFireOffset()
 }

--- a/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
@@ -10,14 +10,37 @@ package net.wurstclient.hacks;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.EnumSetting;
 
 @SearchTags({"no fire overlay"})
 public final class NoFireOverlayHack extends Hack
 {
+	private final EnumSetting<Mode> mode = new EnumSetting<>("Mode",
+		"\u00a7lLower\u00a7r mode lowers the overlay.\n"
+			+ "\u00a7lRemove\u00a7r mode removes the overlay.",
+		Mode.values(), Mode.REMOVE);
+	
 	public NoFireOverlayHack()
 	{
 		super("NoFireOverlay");
 		setCategory(Category.RENDER);
+		addSetting(mode);
+	}
+	
+	public boolean shouldCancelOverlay()
+	{
+		return isEnabled() && mode.getSelected() == Mode.REMOVE;
+	}
+	
+	public boolean shouldLowerOverlay()
+	{
+		return isEnabled() && mode.getSelected() == Mode.LOWER;
+	}
+	
+	private enum Mode
+	{
+		LOWER,
+		REMOVE;
 	}
 	
 	// See InGameOverlayRendererMixin.onRenderFireOverlay()

--- a/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
@@ -9,7 +9,9 @@ package net.wurstclient.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.MinecraftClient;
@@ -27,8 +29,18 @@ public class InGameOverlayRendererMixin
 	private static void onRenderFireOverlay(MinecraftClient minecraftClient,
 		MatrixStack matrixStack, CallbackInfo ci)
 	{
-		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.isEnabled())
+		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.shouldCancelOverlay())
 			ci.cancel();
+	}
+	
+	@ModifyConstant(method =
+		"renderFireOverlay(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/util/math/MatrixStack;)V",
+		constant = @Constant(floatValue = -0.3F))
+	private static float getFireOffset(float orig)
+	{
+		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.shouldLowerOverlay())
+			return -0.5F;
+		return orig;
 	}
 	
 	@Inject(at = {@At("HEAD")},

--- a/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
@@ -22,25 +22,12 @@ import net.wurstclient.WurstClient;
 @Mixin(InGameOverlayRenderer.class)
 public class InGameOverlayRendererMixin
 {
-	@Inject(at = {@At("HEAD")},
-		method = {
-			"renderFireOverlay(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/util/math/MatrixStack;)V"},
-		cancellable = true)
-	private static void onRenderFireOverlay(MinecraftClient minecraftClient,
-		MatrixStack matrixStack, CallbackInfo ci)
-	{
-		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.shouldCancelOverlay())
-			ci.cancel();
-	}
-	
 	@ModifyConstant(method =
 		"renderFireOverlay(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/util/math/MatrixStack;)V",
 		constant = @Constant(floatValue = -0.3F))
 	private static float getFireOffset(float orig)
 	{
-		if(WurstClient.INSTANCE.getHax().noFireOverlayHack.shouldLowerOverlay())
-			return -0.5F;
-		return orig;
+		return orig - WurstClient.INSTANCE.getHax().noFireOverlayHack.getOverlayOffset();
 	}
 	
 	@Inject(at = {@At("HEAD")},


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

This PR adds an option to lower the fire overlay. Currently, the only options are to eliminate the fire overlay or to have the overlay block half the screen, both of which have their downsides.

This is an updated version of #118.
