### PR TITLE
Fix chat messages not being logged

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ChatHudMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ChatHudMixin.java
@@ -54,9 +54,16 @@ public class ChatHudMixin extends DrawableHelper
 		message = event.getComponent();
 		indicator = WurstClient.INSTANCE.getOtfs().noChatReportsOtf
 			.modifyIndicator(message, signature, indicator);
+		shadow$logChatMessage(message, indicator);
 		shadow$addMessage(message, signature, client.inGameHud.getTicks(),
 			indicator, false);
 		ci.cancel();
+	}
+	
+	@Shadow
+	private void shadow$logChatMessage(Text message, @Nullable MessageIndicator indicator)
+	{
+
 	}
 	
 	@Shadow


### PR DESCRIPTION
<!--NOTE: If you are contributing multiple unrelated features, please create a separate pull request for each feature. Squeezing everything into one giant pull request makes it very difficult for me to add your features, as I have to test, validate and add them one by one. Thank you for your understanding - and thanks again for taking the time to contribute!!-->

Closes #761. In the mixin, logChatMessage is skipped, resulting in chat messages not being logged.

Credit to isjerryxiao for suggesting this fix.
