### PR TITLE
More options for nobackground

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NoBackgroundHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoBackgroundHack.java
@@ -7,18 +7,39 @@
  */
 package net.wurstclient.hacks;
 
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
 
 @SearchTags({"no background", "NoGuiBackground", "no gui background",
 	"NoGradient", "no gradient"})
 public final class NoBackgroundHack extends Hack
 {
+	public final CheckboxSetting allGuis = new CheckboxSetting("All GUIs",
+		"Removes the background for all GUIs", false);
+	
 	public NoBackgroundHack()
 	{
 		super("NoBackground");
 		setCategory(Category.RENDER);
+		addSetting(allGuis);
+	}
+	
+	public boolean shouldCancelBackground(Screen screen)
+	{
+		if(!isEnabled())
+			return false;
+		
+		if(screen instanceof HandledScreen)
+			return true;
+		
+		if(allGuis.isChecked() && MC.world != null)
+			return true;
+		
+		return false;
 	}
 	
 	// See ScreenMixin.onRenderBackground()

--- a/src/main/java/net/wurstclient/mixin/ScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ScreenMixin.java
@@ -37,7 +37,7 @@ public abstract class ScreenMixin extends AbstractParentElement
 		cancellable = true)
 	public void onRenderBackground(MatrixStack matrices, CallbackInfo ci)
 	{
-		if(WurstClient.INSTANCE.getHax().noBackgroundHack.isEnabled())
+		if(WurstClient.INSTANCE.getHax().noBackgroundHack.shouldCancelBackground((Screen)(Object)this))
 			ci.cancel();
 	}
 	


### PR DESCRIPTION
This PR disables NoBackground when a world is not loaded, as well as an option to only remove the background from inventories.

This fix combines #621 and #335 to allow users to choose if they want the non-inventory GUIs to have the background.