### PR TITLE
Fix AntiWaterPush affecting other entities

### DIFF
--- a/src/main/java/net/wurstclient/events/VelocityFromFluidListener.java
+++ b/src/main/java/net/wurstclient/events/VelocityFromFluidListener.java
@@ -9,6 +9,7 @@ package net.wurstclient.events;
 
 import java.util.ArrayList;
 
+import net.minecraft.entity.Entity;
 import net.wurstclient.event.CancellableEvent;
 import net.wurstclient.event.Listener;
 
@@ -19,6 +20,18 @@ public interface VelocityFromFluidListener extends Listener
 	public static class VelocityFromFluidEvent
 		extends CancellableEvent<VelocityFromFluidListener>
 	{
+		private final Entity entity;
+		
+		public VelocityFromFluidEvent(Entity entity)
+		{
+			this.entity = entity;
+		}
+		
+		public Entity getEntity()
+		{
+			return entity;
+		}
+		
 		@Override
 		public void fire(ArrayList<VelocityFromFluidListener> listeners)
 		{

--- a/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
@@ -68,7 +68,8 @@ public final class AntiWaterPushHack extends Hack implements UpdateListener,
 	@Override
 	public void onVelocityFromFluid(VelocityFromFluidEvent event)
 	{
-		event.cancel();
+		if(event.getEntity() == MC.player)
+			event.cancel();
 	}
 	
 	@Override

--- a/src/main/java/net/wurstclient/mixin/EntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityMixin.java
@@ -29,7 +29,7 @@ public abstract class EntityMixin implements Nameable, CommandOutput
 		method = "updateMovementInFluid(Lnet/minecraft/registry/tag/TagKey;D)Z")
 	private void setVelocityFromFluid(Entity entity, Vec3d velocity)
 	{
-		VelocityFromFluidEvent event = new VelocityFromFluidEvent();
+		VelocityFromFluidEvent event = new VelocityFromFluidEvent((Entity)(Object)this);
 		EventManager.fire(event);
 		
 		if(!event.isCancelled())


### PR DESCRIPTION
Closes #767. Now NoWaterPush will no longer affect entities that are not the player.