### PR TITLE
NameTags Improvements

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NameTagsHack.java
+++ b/src/main/java/net/wurstclient/hacks/NameTagsHack.java
@@ -10,14 +10,32 @@ package net.wurstclient.hacks;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
 
 @SearchTags({"name tags"})
 public final class NameTagsHack extends Hack
 {
+	private final CheckboxSetting alwaysVisible = new CheckboxSetting(
+		"Always See NameTags", false);	
+	private final CheckboxSetting unlimited = new CheckboxSetting(
+		"Unlimited Range Nametags", false);
+
 	public NameTagsHack()
 	{
 		super("NameTags");
 		setCategory(Category.RENDER);
+		addSetting(alwaysVisible);	
+		addSetting(unlimited);
+	}
+
+	public boolean alwaysVisibleNametags()
+	{
+		return isEnabled() && alwaysVisible.isChecked();
+	}
+
+	public boolean isUnlimitedRange()
+	{
+		return isEnabled() && unlimited.isChecked();
 	}
 	
 	// See EntityRendererMixin.wurstRenderLabelIfPresent()

--- a/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
@@ -96,7 +96,7 @@ public abstract class EntityRendererMixin<T extends Entity>
 		
 		if(bl)
 			textRenderer.draw(text.asOrderedText(), h, j, -1, false, matrix4f,
-				vertexConsumerProvider, false, 0, i);
+				vertexConsumerProvider, nameTagsHack.isEnabled() ? true : false, 0, i);
 		
 		matrixStack.pop();
 	}

--- a/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
@@ -58,12 +58,12 @@ public abstract class EntityRendererMixin<T extends Entity>
 		MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider,
 		int i)
 	{
+		NameTagsHack nameTagsHack = WurstClient.INSTANCE.getHax().nameTagsHack;
+		
 		double d = this.dispatcher.getSquaredDistanceToCamera(entity);
 		
-		if(d > 4096)
+		if(d > 4096 && !nameTagsHack.isUnlimitedRange())
 			return;
-		
-		NameTagsHack nameTagsHack = WurstClient.INSTANCE.getHax().nameTagsHack;
 		
 		boolean bl = !entity.isSneaky() || nameTagsHack.isEnabled();
 		float f = entity.getHeight() + 0.5F;


### PR DESCRIPTION
Closes #739.
-Removes the distance limitation of nametags (normally set to 4,096 blocks distance squared)
-Add option to force show nametags (for example the player model in the inventory screen) (it is possible for servers to hide player nametags, this option ignores this constraint)
-Make nametags show clearly through walls. You can see the differences below:
Before:
![Before](https://user-images.githubusercontent.com/15678918/215201020-71c81c35-2793-4d68-b691-581f7439f16a.png)
After:
![After](https://user-images.githubusercontent.com/15678918/215200826-9f95c342-0e86-4ee3-8366-b825f2138c6a.png)
