### PR TITLE
PlayerCollision

### DIFF
--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -142,6 +142,7 @@ public final class HackList implements UpdateListener
 	public final OverlayHack overlayHack = new OverlayHack();
 	public final PanicHack panicHack = new PanicHack();
 	public final ParkourHack parkourHack = new ParkourHack();
+	public final PlayerCollisionHack playerCollisionHack = new PlayerCollisionHack();
 	public final PlayerEspHack playerEspHack = new PlayerEspHack();
 	public final PlayerFinderHack playerFinderHack = new PlayerFinderHack();
 	public final PortalGuiHack portalGuiHack = new PortalGuiHack();

--- a/src/main/java/net/wurstclient/hacks/PlayerCollisionHack.java
+++ b/src/main/java/net/wurstclient/hacks/PlayerCollisionHack.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2023 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.hacks;
+
+import net.wurstclient.Category;
+import net.wurstclient.SearchTags;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.SliderSetting;
+import net.wurstclient.settings.SliderSetting.ValueDisplay;
+
+@SearchTags({"no push", "anticollide", "anti collision"})
+public final class PlayerCollisionHack extends Hack
+{
+	private final SliderSetting reduction =
+		new SliderSetting("Reduction Percentage",
+			"Reduces collision by the specified percent.\n"
+			+ "Values over 100% will cause you to move towards the entity.",
+			1, 0, 4, 0.05, ValueDisplay.PERCENTAGE);
+	
+	public PlayerCollisionHack()
+	{
+		super("PlayerCollision");
+		setCategory(Category.OTHER);
+		addSetting(reduction);
+	}
+	
+	public double getCollisionReduction()
+	{
+		return isEnabled() ? reduction.getValue() : 0;
+	}
+	
+	// See EntityMixin.adjustPlayerCollision()
+}

--- a/src/main/java/net/wurstclient/mixin/EntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityMixin.java
@@ -10,12 +10,15 @@ package net.wurstclient.mixin;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.server.command.CommandOutput;
 import net.minecraft.util.Nameable;
 import net.minecraft.util.math.Vec3d;
+import net.wurstclient.WurstClient;
 import net.wurstclient.event.EventManager;
 import net.wurstclient.events.VelocityFromFluidListener.VelocityFromFluidEvent;
 
@@ -34,5 +37,15 @@ public abstract class EntityMixin implements Nameable, CommandOutput
 		
 		if(!event.isCancelled())
 			entity.setVelocity(velocity);
+	}
+	
+	@ModifyConstant(method =
+		"pushAwayFrom(Lnet/minecraft/entity/Entity;)V",
+		constant = @Constant(doubleValue = 0.05000000074505806D))
+	private double adjustPlayerCollision(double multiplier)
+	{
+		if((Object)this != WurstClient.MC.player)
+			return multiplier;
+		return multiplier * (1 - WurstClient.INSTANCE.getHax().playerCollisionHack.getCollisionReduction());
 	}
 }

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -124,6 +124,7 @@
   "description.wurst.hack.overlay": "Renders the Nuker animation whenever you mine a block.",
   "description.wurst.hack.panic": "Instantly turns off all enabled hacks.\nBe careful with this one!",
   "description.wurst.hack.parkour": "Makes you jump automatically when reaching the edge of a block.\nUseful for parkours and jump'n'runs.",
+  "description.wurst.hack.playercollision": "Changes the collision effect when colliding with entities.",
   "description.wurst.hack.playeresp": "Highlights nearby players.\nESP boxes of friends will appear in blue.",
   "description.wurst.hack.playerfinder": "Finds far away players during thunderstorms.",
   "description.wurst.hack.portalgui": "Allows you to open GUIs in portals.",


### PR DESCRIPTION
Changes the player behavior when colliding with entities. By default, this prevents the player from being pushed by other entities, but this can be configured so that the player actually moves toward the entity, which might be useful when you want to push an entity.