### PR TITLE
Create nightly builds on CI runs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,3 +42,10 @@ jobs:
       uses: gradle/gradle-build-action@v2
     - name: Execute Gradle build
       run: ./gradlew build
+    - name: Prepare build artifacts
+      run: rm build/libs/Wurst-Client-*-sources.jar && mv build/libs/Wurst-Client-*.jar "build/libs/Wurst-Client-${{github.WORKFLOW_SHA}}.jar"
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Wurst-Client nightly-${{github.WORKFLOW_SHA}}
+        path: "build/libs/Wurst-Client-${{github.WORKFLOW_SHA}}.jar"


### PR DESCRIPTION
## Description
With each build that triggers the CI, a nightly build is now compiled.

If I see changes in the code that I'd like to use already, I don't want to have to set the repo up first.

So I think it might be a good idea to create artifacts in the CI runs.