### PR TITLE
Anti-X-Ray exposed blocks

### DIFF
--- a/src/main/java/net/wurstclient/events/ShouldDrawSideListener.java
+++ b/src/main/java/net/wurstclient/events/ShouldDrawSideListener.java
@@ -10,6 +10,7 @@ package net.wurstclient.events;
 import java.util.ArrayList;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
 import net.wurstclient.event.Event;
 import net.wurstclient.event.Listener;
 
@@ -21,18 +22,24 @@ public interface ShouldDrawSideListener extends Listener
 		extends Event<ShouldDrawSideListener>
 	{
 		private final BlockState state;
+		private final BlockPos pos;
 		private Boolean rendered;
 		
-		public ShouldDrawSideEvent(BlockState state)
+		public ShouldDrawSideEvent(BlockState state, BlockPos pos)
 		{
 			this.state = state;
+			this.pos = pos;
 		}
 		
 		public BlockState getState()
 		{
 			return state;
 		}
-		
+
+		public BlockPos getPos() {
+			return pos;
+		}
+
 		public Boolean isRendered()
 		{
 			return rendered;

--- a/src/main/java/net/wurstclient/events/TesselateBlockListener.java
+++ b/src/main/java/net/wurstclient/events/TesselateBlockListener.java
@@ -10,6 +10,7 @@ package net.wurstclient.events;
 import java.util.ArrayList;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
 import net.wurstclient.event.CancellableEvent;
 import net.wurstclient.event.Listener;
 
@@ -21,17 +22,23 @@ public interface TesselateBlockListener extends Listener
 		extends CancellableEvent<TesselateBlockListener>
 	{
 		private final BlockState state;
+		private final BlockPos pos;
 		
-		public TesselateBlockEvent(BlockState state)
+		public TesselateBlockEvent(BlockState state, BlockPos pos)
 		{
 			this.state = state;
+			this.pos = pos;
 		}
 		
 		public BlockState getState()
 		{
 			return state;
 		}
-		
+
+		public BlockPos getPos() {
+			return pos;
+		}
+
 		@Override
 		public void fire(ArrayList<TesselateBlockListener> listeners)
 		{

--- a/src/main/java/net/wurstclient/hacks/XRayHack.java
+++ b/src/main/java/net/wurstclient/hacks/XRayHack.java
@@ -85,25 +85,25 @@ public final class XRayHack extends Hack implements UpdateListener,
 
 	private ArrayList<String> oreNames;
 
-	private final BlockListSetting exposedBlocks = new BlockListSetting("Exposed", "Blocks to filter as exposed",
-			"minecraft:air",
-			"minecraft:big_dripleaf",
-			"minecraft:big_dripleaf_stem",
-			"minecraft:big_pointed_dripstone",
-			"minecraft:cave_air",
-			"minecraft:cave_vines",
-			"minecraft:iron_bars",
-			"minecraft:iron_door",
-			"minecraft:lava",
-			"minecraft:oak_fence",
-			"minecraft:pointed_dripstone",
-			"minecraft:small_dripleaf",
-			"minecraft:vine",
-			"minecraft:water");
+	//private final BlockListSetting exposedBlocks = new BlockListSetting("Exposed", "Blocks to filter as exposed",
+	//		"minecraft:air",
+	//		"minecraft:big_dripleaf",
+	//		"minecraft:big_dripleaf_stem",
+	//		"minecraft:big_pointed_dripstone",
+	//		"minecraft:cave_air",
+	//		"minecraft:cave_vines",
+	//		"minecraft:iron_bars",
+	//		"minecraft:iron_door",
+	//		"minecraft:lava",
+	//		"minecraft:oak_fence",
+	//		"minecraft:pointed_dripstone",
+	//		"minecraft:small_dripleaf",
+	//		"minecraft:vine",
+	//		"minecraft:water");
 
-	private ArrayList<String> exposedNames;
+	//private ArrayList<String> exposedNames;
 
-	private final CheckboxSetting showExposed = new CheckboxSetting("Show exposed", "Only show ores touching visible blocks.\nUseful for dealing with anti-xray plugins.\nReenable this hack if nothing appears changed.", false);
+	private final CheckboxSetting showExposed = new CheckboxSetting("Show exposed", "Only show exposed ores touching air/water/lava.\nUseful for servers utilizing anti-X-Ray.\nReenable this hack if nothing appears changed.", false);
 
 	// TODO does anyone use optifine anymore?
 	// 		closed source + alternatives like sodium = why
@@ -117,7 +117,7 @@ public final class XRayHack extends Hack implements UpdateListener,
 		super("X-Ray");
 		setCategory(Category.RENDER);
 		addSetting(ores);
-		addSetting(exposedBlocks);
+		//addSetting(exposedBlocks);
 		addSetting(showExposed);
 		
 		List<String> mods = FabricLoader.getInstance().getAllMods().stream()
@@ -143,7 +143,7 @@ public final class XRayHack extends Hack implements UpdateListener,
 	{
 		// TODO BlockList already contains an ArrayList, why not just use that?
 		oreNames = new ArrayList<>(ores.getBlockNames());
-		exposedNames = new ArrayList<>(exposedBlocks.getBlockNames());
+		//exposedNames = new ArrayList<>(exposedBlocks.getBlockNames());
 		
 		EVENTS.add(UpdateListener.class, this);
 		EVENTS.add(SetOpaqueCubeListener.class, this);
@@ -234,12 +234,22 @@ public final class XRayHack extends Hack implements UpdateListener,
 		boolean visible = index >= 0;
 
 		if (visible && showExposed.isChecked()) {
-			return Collections.binarySearch(exposedNames, BlockUtils.getName(pos.up())) >= 0
-					|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.down())) >= 0
-					|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.east())) >= 0
-					|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.west())) >= 0
-					|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.north())) >= 0
-					|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.south())) >= 0;
+			// TODO this only considers blocks with no hitbox
+			//		shouldnt blocks like fences, vines be considered exposed?
+			//		this works for most cases so its probably redundant...
+			return !BlockUtils.canBeClicked(pos.up())
+					|| !BlockUtils.canBeClicked(pos.down())
+					|| !BlockUtils.canBeClicked(pos.east())
+					|| !BlockUtils.canBeClicked(pos.west())
+					|| !BlockUtils.canBeClicked(pos.north())
+					|| !BlockUtils.canBeClicked(pos.south());
+
+			//return Collections.binarySearch(exposedNames, BlockUtils.getName(pos.up())) >= 0
+			//		|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.down())) >= 0
+			//		|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.east())) >= 0
+			//		|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.west())) >= 0
+			//		|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.north())) >= 0
+			//		|| Collections.binarySearch(exposedNames, BlockUtils.getName(pos.south())) >= 0;
 
 			//return EXPOSED_NEIGHBOUR_BLOCKS.contains(BlockUtils.getBlock(pos.up()))
 			//		|| EXPOSED_NEIGHBOUR_BLOCKS.contains(BlockUtils.getBlock(pos.down()))

--- a/src/main/java/net/wurstclient/mixin/BlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockMixin.java
@@ -34,7 +34,7 @@ public abstract class BlockMixin implements ItemConvertible
 		BlockPos pos, Direction direction, BlockPos blockPos,
 		CallbackInfoReturnable<Boolean> cir)
 	{
-		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state);
+		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, pos);
 		EventManager.fire(event);
 		
 		if(event.isRendered() != null)

--- a/src/main/java/net/wurstclient/mixin/BlockModelRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockModelRendererMixin.java
@@ -38,9 +38,9 @@ public abstract class BlockModelRendererMixin
 		VertexConsumer vertexConsumer, boolean cull, Random random, long seed,
 		int overlay, CallbackInfo ci)
 	{
-		TesselateBlockEvent event = new TesselateBlockEvent(state);
+		TesselateBlockEvent event = new TesselateBlockEvent(state, pos);
 		EventManager.fire(event);
-		
+
 		if(event.isCancelled())
 		{
 			ci.cancel();
@@ -50,7 +50,7 @@ public abstract class BlockModelRendererMixin
 		if(!cull)
 			return;
 		
-		ShouldDrawSideEvent event2 = new ShouldDrawSideEvent(state);
+		ShouldDrawSideEvent event2 = new ShouldDrawSideEvent(state, pos);
 		EventManager.fire(event2);
 		if(!Boolean.TRUE.equals(event2.isRendered()))
 			return;

--- a/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
@@ -32,7 +32,7 @@ public class FluidRendererMixin
 		CallbackInfoReturnable<Boolean> cir)
 	{
 		BlockState state = blockView.getBlockState(blockPos);
-		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state);
+		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, blockPos);
 		EventManager.fire(event);
 		
 		if(event.isRendered() != null)

--- a/src/main/java/net/wurstclient/mixin/SodiumBlockOcclusionCacheMixin.java
+++ b/src/main/java/net/wurstclient/mixin/SodiumBlockOcclusionCacheMixin.java
@@ -34,7 +34,7 @@ public class SodiumBlockOcclusionCacheMixin
 		Direction facing, CallbackInfoReturnable<Boolean> cir)
 	{
 		ShouldDrawSideListener.ShouldDrawSideEvent event =
-			new ShouldDrawSideListener.ShouldDrawSideEvent(state);
+			new ShouldDrawSideListener.ShouldDrawSideEvent(state, pos);
 		EventManager.fire(event);
 		
 		if(event.isRendered() != null)

--- a/src/main/java/net/wurstclient/mixin/TerrainRenderContextMixin.java
+++ b/src/main/java/net/wurstclient/mixin/TerrainRenderContextMixin.java
@@ -39,7 +39,7 @@ public class TerrainRenderContextMixin
 	private void onTessellateBlock(BlockState blockState, BlockPos blockPos,
 		final BakedModel model, MatrixStack matrixStack, CallbackInfo ci)
 	{
-		TesselateBlockEvent event = new TesselateBlockEvent(blockState);
+		TesselateBlockEvent event = new TesselateBlockEvent(blockState, blockPos);
 		EventManager.fire(event);
 		
 		if(event.isCancelled())

--- a/src/main/java/net/wurstclient/settings/BlockListSetting.java
+++ b/src/main/java/net/wurstclient/settings/BlockListSetting.java
@@ -33,6 +33,8 @@ import net.wurstclient.util.json.WsonArray;
 
 public final class BlockListSetting extends Setting
 {
+	// TODO blocks which cannot be visually represented as items default to 'unknown',
+	//		ie water, air, lava, nether_portal, end_portal, ...
 	private final ArrayList<String> blockNames = new ArrayList<>();
 	private final String[] defaultNames;
 	


### PR DESCRIPTION
## Description
This is a feature for X-Ray to deal with servers utilizing Anti-X-Ray. This is not a bypass, but rather a band-aid that makes X-Ray not outright useless on these servers (https://github.com/Wurst-Imperium/Wurst7/issues/860). 

## Findings
When X-Ray is enabled and the feature 'Show exposed' is toggled to enable, sometimes nothing changes. Disabling and enabling X-Ray seems to show the changes.

`BlockUtils.canBeClicked` is what is currently being used. Should fences, leaves, and other non-solid blocks be considered? Currently only air, water and lava are the primary exposed blocks. I left some comments and unused code that shows what I mean in reference to some non-solid blocks when initially testing.

## Transparent / non-solids

X-Ray disabled
![2023-08-14_11 11 11](https://github.com/Wurst-Imperium/Wurst7/assets/47781580/a5205ca3-c28c-40e0-9088-8bdb807f4ba1)

X-Ray enabled
![2023-08-14_11 11 19](https://github.com/Wurst-Imperium/Wurst7/assets/47781580/606184ae-7e19-4e46-bfd8-bc45ed639481)