### PR TITLE
ItemEsp display info

### DIFF
--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -10,6 +10,7 @@ package net.wurstclient.hacks;
 import java.awt.Color;
 import java.util.ArrayList;
 
+import net.wurstclient.settings.CheckboxSetting;
 import org.joml.Matrix4f;
 import org.lwjgl.opengl.GL11;
 
@@ -41,6 +42,18 @@ import net.wurstclient.util.RotationUtils;
 public final class ItemEspHack extends Hack implements UpdateListener,
 	CameraTransformViewBobbingListener, RenderListener
 {
+	/*
+	 * I don't know where to put this
+	 * 	https://github.com/Wurst-Imperium/Wurst7/issues/638
+	 * Item-despawn timers and other data can be displayed
+	 *	as part of the entity item nametag
+	 * Nametags hack has similar functionality to these proposals,
+	 * 	forcibly making the item name visible, but ItemEntityRenderer::hasLabel
+	 *
+	 * Entity::setCustomNameVisible achieves the same thing, perhaps
+	 * 	inject Entity::isCustomNameVisible to return true?
+	 */
+
 	private final EnumSetting<Style> style =
 		new EnumSetting<>("Style", Style.values(), Style.BOXES);
 	
@@ -53,7 +66,13 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 		"Items will be highlighted in this color.", Color.YELLOW);
 	
 	private final ArrayList<ItemEntity> items = new ArrayList<>();
-	
+
+	private final CheckboxSetting renderItemInfo = new CheckboxSetting("Show status", "Show status of item such as despawn time", false);
+
+	public boolean shouldRenderItemInfo() {
+		return renderItemInfo.isChecked();
+	}
+
 	public ItemEspHack()
 	{
 		super("ItemESP");
@@ -62,6 +81,7 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 		addSetting(style);
 		addSetting(boxSize);
 		addSetting(color);
+		addSetting(renderItemInfo);
 	}
 	
 	@Override

--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -70,7 +70,7 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 	private final CheckboxSetting renderItemInfo = new CheckboxSetting("Show status", "Show status of item such as despawn time", false);
 
 	public boolean shouldRenderItemInfo() {
-		return renderItemInfo.isChecked();
+		return isEnabled() && renderItemInfo.isChecked();
 	}
 
 	public ItemEspHack()

--- a/src/main/java/net/wurstclient/mixin/EntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityMixin.java
@@ -62,13 +62,31 @@ public abstract class EntityMixin implements Nameable, CommandOutput
 			method = "getDisplayName()Lnet/minecraft/text/Text;",
 			cancellable = true)
 	private void onGetDisplayName(CallbackInfoReturnable<Text> cir) {
+		//noinspection ConstantValue
 		if ((Object)this instanceof ItemEntity
 				&& WurstClient.INSTANCE.getHax().itemEspHack.shouldRenderItemInfo())
 		{
 			ItemEntity itemEntity = (ItemEntity) ((Object)this);
-			float seconds = ((6000 - itemEntity.getItemAge()) / 20.f);
-			cir.setReturnValue(Text.of(String.format("Despawns in %.02f", seconds)));
+			int itemAgeRemaining = (6000 - itemEntity.getItemAge()) / 20;
+
+			// There is a problem with this
+			//	TimerHack (or any other client-side delta manipulation) interferes
+			//	Single player world instances cause item ages to be inaccurate to
+			//	the locally started server instance
+			// Single Player worlds start an internal server (MC.server) that is separate from the client MC.world
+			//	In the serverworld, the item age works as expected, however, item age (with TimerHack enabled)
+			//		is not accurate
+
+			// 1.19 hex-colors could easily be used
+			//	like a gradient from green->yellow->orange->red
+
+			String text = String.format("\u00a7%s%ds",
+					itemAgeRemaining < 15 ? "4" : itemAgeRemaining < 60 ? ("c") : itemAgeRemaining < 180 ? "6" : "2",
+					itemAgeRemaining);
+
+			cir.setReturnValue(Text.of(text));
+
+			//cir.setReturnValue(Text.of(String.format("age: %.01fs, itemAge: %.01f", ageSeconds, itemAgeSeconds)));
 		}
-		//cir.setReturnValue();
 	}
 }

--- a/src/main/java/net/wurstclient/mixin/EntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityMixin.java
@@ -80,6 +80,8 @@ public abstract class EntityMixin implements Nameable, CommandOutput
 			// 1.19 hex-colors could easily be used
 			//	like a gradient from green->yellow->orange->red
 
+			// Maybe show the distance away?
+			//	Not sure what other information to provide
 			String text = String.format("\u00a7%s%ds",
 					itemAgeRemaining < 15 ? "4" : itemAgeRemaining < 60 ? ("c") : itemAgeRemaining < 180 ? "6" : "2",
 					itemAgeRemaining);

--- a/src/main/java/net/wurstclient/mixin/EntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityMixin.java
@@ -7,6 +7,10 @@
  */
 package net.wurstclient.mixin;
 
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.text.Text;
+import net.wurstclient.WurstClient;
+import net.wurstclient.util.ColorUtils;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -21,6 +25,7 @@ import net.minecraft.util.math.Vec3d;
 import net.wurstclient.event.EventManager;
 import net.wurstclient.events.VelocityFromEntityCollisionListener.VelocityFromEntityCollisionEvent;
 import net.wurstclient.events.VelocityFromFluidListener.VelocityFromFluidEvent;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
 public abstract class EntityMixin implements Nameable, CommandOutput
@@ -51,5 +56,19 @@ public abstract class EntityMixin implements Nameable, CommandOutput
 		
 		if(event.isCancelled())
 			ci.cancel();
+	}
+
+	@Inject(at = @At("HEAD"),
+			method = "getDisplayName()Lnet/minecraft/text/Text;",
+			cancellable = true)
+	private void onGetDisplayName(CallbackInfoReturnable<Text> cir) {
+		if ((Object)this instanceof ItemEntity
+				&& WurstClient.INSTANCE.getHax().itemEspHack.shouldRenderItemInfo())
+		{
+			ItemEntity itemEntity = (ItemEntity) ((Object)this);
+			float seconds = ((6000 - itemEntity.getItemAge()) / 20.f);
+			cir.setReturnValue(Text.of(String.format("Despawns in %.02f", seconds)));
+		}
+		//cir.setReturnValue();
 	}
 }

--- a/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
@@ -7,6 +7,7 @@
  */
 package net.wurstclient.mixin;
 
+import net.minecraft.entity.ItemEntity;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -26,6 +27,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.text.Text;
 import net.wurstclient.WurstClient;
 import net.wurstclient.hacks.NameTagsHack;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(EntityRenderer.class)
 public abstract class EntityRendererMixin<T extends Entity>
@@ -110,7 +112,29 @@ public abstract class EntityRendererMixin<T extends Entity>
 		
 		matrices.pop();
 	}
-	
+
+	/**
+	 * Forces the nametag to be rendered if configured in NameTags.
+	 */
+	@Inject(at = @At("HEAD"),
+			method = "hasLabel(Lnet/minecraft/entity/Entity;)Z",
+			cancellable = true)
+	private void shouldForceLabel(Entity e,
+								  CallbackInfoReturnable<Boolean> cir)
+	{
+		if (e instanceof ItemEntity
+				&& WurstClient.INSTANCE.getHax().itemEspHack.shouldRenderItemInfo())
+		{
+			cir.setReturnValue(true);
+		}
+		// return true immediately after the distance check
+		//if(WurstClient.INSTANCE.getHax().nameTagsHack.shouldForceNametags())
+		// e.getDisplayName()
+	}
+
+
+
+
 	@Shadow
 	public TextRenderer getTextRenderer()
 	{


### PR DESCRIPTION
## Description
Added setting to ItemEsp showing time until despawn (https://github.com/Wurst-Imperium/Wurst7/issues/638).

This is the only addition ATM, but other stats such as distance and 'value' of item can be easily added.

## Findings
Using TimerHack in conjunction with despawn timers makes them tick faster. This is a client side-effect due to the way TimerHack works. On single-player worlds, host client contains a usable MC.server instance which contains correct unmodified item ages.

This is proven by running `/data` command on the item entity, showing how the **server** item age is different from the **client** item age.

Solution? Either do not use TimerHack with despawn timers, or store all item ages prior to enabling TimerHack (in anticipation of enabling ItemEsp). This seems a bit excessive. 

Moving the camera around when facing the item appears to apply shading in the form of lighter or darker color codes. 

![2023-08-14_12 43 45](https://github.com/Wurst-Imperium/Wurst7/assets/47781580/f46b64f1-2505-4a23-951d-5c0755e56984)
