### PR TITLE
Fixed sleeping filter

### DIFF
--- a/src/main/java/net/wurstclient/settings/filters/FilterSleepingSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterSleepingSetting.java
@@ -8,6 +8,7 @@
 package net.wurstclient.settings.filters;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.player.PlayerEntity;
 
 public final class FilterSleepingSetting extends EntityFilterCheckbox
@@ -22,8 +23,8 @@ public final class FilterSleepingSetting extends EntityFilterCheckbox
 	{
 		if(!(e instanceof PlayerEntity))
 			return true;
-		
-		return !((PlayerEntity)e).isSleeping();
+
+		return e.getPose() != EntityPose.SLEEPING && !((PlayerEntity)e).isSleeping();
 	}
 	
 	public static FilterSleepingSetting genericCombat(boolean checked)


### PR DESCRIPTION
## Description
Sleeping filter not correctly targeting players in sleep pose while not sleeping in bed.

This can be tested in a Hypixel Murder Mystery game. Prior to this change, fallen players would still be shown although sleeping filter is enabled.
