### PR TITLE
basic implementation of XDG base directory for alt folder

### DIFF
--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -154,7 +154,8 @@ public enum WurstClient
 		if((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null
 			&& !xdg_data_home.isEmpty())
 		{
-			encFolder = Paths.get(xdg_data_home, ".Wurst encryption").normalize();
+			encFolder =
+				Paths.get(xdg_data_home, ".Wurst encryption").normalize();
 			if(!Files.exists(encFolder) && Files.isDirectory(oldEncFolder))
 				Encryption.migrateEncryptionFolder(oldEncFolder, encFolder);
 		}else

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -145,9 +145,19 @@ public enum WurstClient
 		problematicPackDetector.start();
 		
 		Path altsFile = wurstFolder.resolve("alts.encrypted_json");
-		Path encFolder =
-			Paths.get(System.getProperty("user.home"), ".Wurst encryption")
+		Path encFolder;
+		String xdg_data_home;
+		if ((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null)
+		{
+			encFolder = Paths.get(xdg_data_home, "WurstClient")
 				.normalize();
+		}
+		else 
+		{
+			encFolder = Paths.get(System.getProperty("user.home", ".Wurst encryption"))
+				.normalize();
+		}
+
 		altManager = new AltManager(altsFile, encFolder);
 		
 		zoomKey = new KeyBinding("key.wurst.zoom", InputUtil.Type.KEYSYM,

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -146,20 +146,20 @@ public enum WurstClient
 		problematicPackDetector.start();
 		
 		Path altsFile = wurstFolder.resolve("alts.encrypted_json");
-		Path oldEncFolder =
-			Paths.get(System.getProperty("user.home"), ".Wurst encryption")
-				.normalize();
-		Path encFolder;
-		String xdg_data_home;
-		if((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null
-			&& !xdg_data_home.isEmpty())
+		
+		String userHome = System.getProperty("user.home");
+		String xdgDataHome = System.getenv("XDG_DATA_HOME");
+		String encFolderName = ".Wurst encryption";
+		
+		Path homeEncFolder = Paths.get(userHome, encFolderName).normalize();
+		Path encFolder = homeEncFolder;
+		if(xdgDataHome != null && !xdgDataHome.isEmpty())
 		{
-			encFolder =
-				Paths.get(xdg_data_home, ".Wurst encryption").normalize();
-			if(!Files.exists(encFolder) && Files.isDirectory(oldEncFolder))
-				Encryption.migrateEncryptionFolder(oldEncFolder, encFolder);
-		}else
-			encFolder = oldEncFolder;
+			encFolder = Paths.get(xdgDataHome, encFolderName).normalize();
+			
+			if(!Files.exists(encFolder) && Files.isDirectory(homeEncFolder))
+				Encryption.migrateEncryptionFolder(homeEncFolder, encFolder);
+		}
 		
 		altManager = new AltManager(altsFile, encFolder);
 		

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -147,7 +147,7 @@ public enum WurstClient
 		Path altsFile = wurstFolder.resolve("alts.encrypted_json");
 		Path encFolder;
 		String xdg_data_home;
-		if ((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null)
+		if ((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null && !xdg_data_home.isEmpty())
 		{
 			encFolder = Paths.get(xdg_data_home, "WurstClient")
 				.normalize();

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -10,7 +10,6 @@ package net.wurstclient;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -146,21 +145,7 @@ public enum WurstClient
 		problematicPackDetector.start();
 		
 		Path altsFile = wurstFolder.resolve("alts.encrypted_json");
-		
-		String userHome = System.getProperty("user.home");
-		String xdgDataHome = System.getenv("XDG_DATA_HOME");
-		String encFolderName = ".Wurst encryption";
-		
-		Path homeEncFolder = Paths.get(userHome, encFolderName).normalize();
-		Path encFolder = homeEncFolder;
-		if(xdgDataHome != null && !xdgDataHome.isEmpty())
-		{
-			encFolder = Paths.get(xdgDataHome, encFolderName).normalize();
-			
-			if(!Files.exists(encFolder) && Files.isDirectory(homeEncFolder))
-				Encryption.migrateEncryptionFolder(homeEncFolder, encFolder);
-		}
-		
+		Path encFolder = Encryption.chooseEncryptionFolder();
 		altManager = new AltManager(altsFile, encFolder);
 		
 		zoomKey = new KeyBinding("key.wurst.zoom", InputUtil.Type.KEYSYM,

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -48,6 +48,7 @@ import net.wurstclient.settings.SettingsFile;
 import net.wurstclient.update.ProblematicResourcePackDetector;
 import net.wurstclient.update.WurstUpdater;
 import net.wurstclient.util.json.JsonException;
+import net.wurstclient.altmanager.Encryption;
 
 public enum WurstClient
 {
@@ -145,17 +146,22 @@ public enum WurstClient
 		problematicPackDetector.start();
 		
 		Path altsFile = wurstFolder.resolve("alts.encrypted_json");
+		Path oldEncFolder = Paths.get(System.getProperty("user.home"), ".Wurst encryption")
+					.normalize(); 
 		Path encFolder;
 		String xdg_data_home;
 		if ((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null && !xdg_data_home.isEmpty())
 		{
 			encFolder = Paths.get(xdg_data_home, "WurstClient")
 				.normalize();
+			if (!Files.exists(encFolder) && Files.exists(oldEncFolder))
+			{
+				Encryption.migrateEncryptionFolder(oldEncFolder, encFolder);
+			}
 		}
 		else 
 		{
-			encFolder = Paths.get(System.getProperty("user.home", ".Wurst encryption"))
-				.normalize();
+			encFolder = oldEncFolder;
 		}
 
 		altManager = new AltManager(altsFile, encFolder);

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -23,6 +23,7 @@ import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.InputUtil;
 import net.wurstclient.altmanager.AltManager;
+import net.wurstclient.altmanager.Encryption;
 import net.wurstclient.analytics.WurstAnalytics;
 import net.wurstclient.clickgui.ClickGui;
 import net.wurstclient.command.CmdList;
@@ -48,7 +49,6 @@ import net.wurstclient.settings.SettingsFile;
 import net.wurstclient.update.ProblematicResourcePackDetector;
 import net.wurstclient.update.WurstUpdater;
 import net.wurstclient.util.json.JsonException;
-import net.wurstclient.altmanager.Encryption;
 
 public enum WurstClient
 {
@@ -146,24 +146,20 @@ public enum WurstClient
 		problematicPackDetector.start();
 		
 		Path altsFile = wurstFolder.resolve("alts.encrypted_json");
-		Path oldEncFolder = Paths.get(System.getProperty("user.home"), ".Wurst encryption")
-					.normalize(); 
+		Path oldEncFolder =
+			Paths.get(System.getProperty("user.home"), ".Wurst encryption")
+				.normalize();
 		Path encFolder;
 		String xdg_data_home;
-		if ((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null && !xdg_data_home.isEmpty())
+		if((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null
+			&& !xdg_data_home.isEmpty())
 		{
-			encFolder = Paths.get(xdg_data_home, "WurstClient")
-				.normalize();
-			if (!Files.exists(encFolder) && Files.exists(oldEncFolder))
-			{
+			encFolder = Paths.get(xdg_data_home, "WurstClient").normalize();
+			if(!Files.exists(encFolder) && Files.exists(oldEncFolder))
 				Encryption.migrateEncryptionFolder(oldEncFolder, encFolder);
-			}
-		}
-		else 
-		{
+		}else
 			encFolder = oldEncFolder;
-		}
-
+		
 		altManager = new AltManager(altsFile, encFolder);
 		
 		zoomKey = new KeyBinding("key.wurst.zoom", InputUtil.Type.KEYSYM,

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -154,7 +154,7 @@ public enum WurstClient
 		if((xdg_data_home = System.getenv("XDG_DATA_HOME")) != null
 			&& !xdg_data_home.isEmpty())
 		{
-			encFolder = Paths.get(xdg_data_home, "WurstClient").normalize();
+			encFolder = Paths.get(xdg_data_home, ".Wurst encryption").normalize();
 			if(!Files.exists(encFolder) && Files.isDirectory(oldEncFolder))
 				Encryption.migrateEncryptionFolder(oldEncFolder, encFolder);
 		}else

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -155,7 +155,7 @@ public enum WurstClient
 			&& !xdg_data_home.isEmpty())
 		{
 			encFolder = Paths.get(xdg_data_home, "WurstClient").normalize();
-			if(!Files.exists(encFolder) && Files.exists(oldEncFolder))
+			if(!Files.exists(encFolder) && Files.isDirectory(oldEncFolder))
 				Encryption.migrateEncryptionFolder(oldEncFolder, encFolder);
 		}else
 			encFolder = oldEncFolder;

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -15,6 +15,7 @@ import java.io.ObjectOutputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -97,6 +98,25 @@ public final class Encryption
 			+ "In other words, YOUR ALT LIST WILL BE DELETED.";
 		Files.write(readme, readmeText.getBytes("UTF-8"),
 			StandardOpenOption.CREATE);
+		
+		return encFolder;
+	}
+	
+	public static Path chooseEncryptionFolder()
+	{
+		String userHome = System.getProperty("user.home");
+		String xdgDataHome = System.getenv("XDG_DATA_HOME");
+		String encFolderName = ".Wurst encryption";
+		
+		Path homeEncFolder = Paths.get(userHome, encFolderName).normalize();
+		Path encFolder = homeEncFolder;
+		if(xdgDataHome != null && !xdgDataHome.isEmpty())
+		{
+			encFolder = Paths.get(xdgDataHome, encFolderName).normalize();
+			
+			if(!Files.exists(encFolder) && Files.isDirectory(homeEncFolder))
+				migrateEncryptionFolder(homeEncFolder, encFolder);
+		}
 		
 		return encFolder;
 	}

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -8,14 +8,13 @@
 package net.wurstclient.altmanager;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.io.File;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -112,14 +111,16 @@ public final class Encryption
 			Files.createDirectories(newEncFolder);
 			Path newEncFolderFileDestinationPath;
 			File oldEncFolderFiles[] = oldEncFolder.toFile().listFiles();
-			for (int i = 0; i < oldEncFolderFiles.length; i++)
+			for(File oldEncFolderFile : oldEncFolderFiles)
 			{
-				newEncFolderFileDestinationPath = newEncFolder.resolve(oldEncFolderFiles[i].getName());
-				Files.copy(oldEncFolderFiles[i].toPath(), newEncFolderFileDestinationPath);
-				oldEncFolderFiles[i].delete();
+				newEncFolderFileDestinationPath =
+					newEncFolder.resolve(oldEncFolderFile.getName());
+				Files.copy(oldEncFolderFile.toPath(),
+					newEncFolderFileDestinationPath);
+				oldEncFolderFile.delete();
 			}
 			Files.deleteIfExists(oldEncFolder);
-
+			
 		}catch(IOException e)
 		{
 			System.out.println("Failed to migrate encryption folder!");

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -108,14 +108,16 @@ public final class Encryption
 		try
 		{
 			Files.createDirectories(newFolder);
-			File[] oldFiles = oldFolder.toFile().listFiles();
 			
+			File[] oldFiles = oldFolder.toFile().listFiles();
 			for(File oldFile : oldFiles)
 			{
 				Path fileDestination = newFolder.resolve(oldFile.getName());
 				Files.copy(oldFile.toPath(), fileDestination);
-				oldFile.delete();
 			}
+			
+			for(File oldFile : oldFiles)
+				oldFile.delete();
 			
 			Files.deleteIfExists(oldFolder);
 			

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -100,26 +100,24 @@ public final class Encryption
 		return encFolder;
 	}
 	
-	public static void migrateEncryptionFolder(Path oldEncFolder,
-		Path newEncFolder)
+	public static void migrateEncryptionFolder(Path oldFolder, Path newFolder)
 	{
-		System.out.println("Migrating encryption folder from " + oldEncFolder
-			+ " to " + newEncFolder);
+		System.out.println("Migrating encryption folder from " + oldFolder
+			+ " to " + newFolder);
 		
 		try
 		{
-			Files.createDirectories(newEncFolder);
-			Path newEncFolderFileDestinationPath;
-			File oldEncFolderFiles[] = oldEncFolder.toFile().listFiles();
-			for(File oldEncFolderFile : oldEncFolderFiles)
+			Files.createDirectories(newFolder);
+			File[] oldFiles = oldFolder.toFile().listFiles();
+			
+			for(File oldFile : oldFiles)
 			{
-				newEncFolderFileDestinationPath =
-					newEncFolder.resolve(oldEncFolderFile.getName());
-				Files.copy(oldEncFolderFile.toPath(),
-					newEncFolderFileDestinationPath);
-				oldEncFolderFile.delete();
+				Path fileDestination = newFolder.resolve(oldFile.getName());
+				Files.copy(oldFile.toPath(), fileDestination);
+				oldFile.delete();
 			}
-			Files.deleteIfExists(oldEncFolder);
+			
+			Files.deleteIfExists(oldFolder);
 			
 		}catch(IOException e)
 		{

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -106,19 +106,11 @@ public final class Encryption
 		System.out.println("Migrating encryption folder from " + oldEncFolder
 			+ " to " + newEncFolder);
 		
-		String readmeText = "Wurst encryption files have been moved to "
-			+ newEncFolder.normalize().toString()
-			+ " to comply with XDG base directory, you may safely remove this directory.\r\n";
-		
 		try
 		{
 			Files.createDirectories(newEncFolder);
 			Files.move(oldEncFolder, newEncFolder,
 				StandardCopyOption.REPLACE_EXISTING);
-			Files.createDirectories(oldEncFolder);
-			Files.write(oldEncFolder.resolve("README_MIGRATION.txt"),
-				readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
-				
 		}catch(IOException e)
 		{
 			System.out.println("Failed to migrate encryption folder!");

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -40,6 +40,7 @@ import com.google.gson.JsonParser;
 import net.minecraft.util.Util;
 import net.minecraft.util.crash.CrashException;
 import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.CrashReportSection;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
 import net.wurstclient.util.json.WsonArray;
@@ -123,8 +124,12 @@ public final class Encryption
 			
 		}catch(IOException e)
 		{
-			System.out.println("Failed to migrate encryption folder!");
-			e.printStackTrace();
+			CrashReport report =
+				CrashReport.create(e, "Migrating Wurst encryption folder");
+			CrashReportSection section = report.addElement("Migration");
+			section.add("Old path", oldFolder);
+			section.add("New path", newFolder);
+			throw new CrashException(report);
 		}
 	}
 	

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -15,6 +15,7 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.StandardCopyOption;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -97,6 +98,26 @@ public final class Encryption
 			StandardOpenOption.CREATE);
 		
 		return encFolder;
+	}
+
+	public static void migrateEncryptionFolder(Path oldEncFolder, Path newEncFolder)
+	{
+		String readmeText = "Wurst encryption files have been moved to " + newEncFolder.normalize().toString() + " to comply with XDG base directory, you may safely remove this directory.\r\n";
+		if (!Files.exists(newEncFolder) && Files.exists(oldEncFolder))
+		{
+			try
+			{
+				Files.createDirectories(newEncFolder);
+				Files.move(oldEncFolder, newEncFolder, StandardCopyOption.REPLACE_EXISTING);
+				Files.createDirectories(oldEncFolder);
+				Files.write(oldEncFolder.resolve("README_MIGRATION.txt"), readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
+			}
+			catch (IOException e){}
+
+		}
+
+
+
 	}
 	
 	public byte[] decrypt(byte[] bytes)

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -103,9 +103,13 @@ public final class Encryption
 	public static void migrateEncryptionFolder(Path oldEncFolder,
 		Path newEncFolder)
 	{
+		System.out.println("Migrating encryption folder from " + oldEncFolder
+			+ " to " + newEncFolder);
+		
 		String readmeText = "Wurst encryption files have been moved to "
 			+ newEncFolder.normalize().toString()
 			+ " to comply with XDG base directory, you may safely remove this directory.\r\n";
+		
 		if(!Files.exists(newEncFolder) && Files.exists(oldEncFolder))
 			try
 			{
@@ -115,9 +119,12 @@ public final class Encryption
 				Files.createDirectories(oldEncFolder);
 				Files.write(oldEncFolder.resolve("README_MIGRATION.txt"),
 					readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
+				
 			}catch(IOException e)
-			{}
-		
+			{
+				System.out.println("Failed to migrate encryption folder!");
+				e.printStackTrace();
+			}
 	}
 	
 	public byte[] decrypt(byte[] bytes)

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -14,8 +14,8 @@ import java.io.ObjectOutputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -99,25 +99,25 @@ public final class Encryption
 		
 		return encFolder;
 	}
-
-	public static void migrateEncryptionFolder(Path oldEncFolder, Path newEncFolder)
+	
+	public static void migrateEncryptionFolder(Path oldEncFolder,
+		Path newEncFolder)
 	{
-		String readmeText = "Wurst encryption files have been moved to " + newEncFolder.normalize().toString() + " to comply with XDG base directory, you may safely remove this directory.\r\n";
-		if (!Files.exists(newEncFolder) && Files.exists(oldEncFolder))
-		{
+		String readmeText = "Wurst encryption files have been moved to "
+			+ newEncFolder.normalize().toString()
+			+ " to comply with XDG base directory, you may safely remove this directory.\r\n";
+		if(!Files.exists(newEncFolder) && Files.exists(oldEncFolder))
 			try
 			{
 				Files.createDirectories(newEncFolder);
-				Files.move(oldEncFolder, newEncFolder, StandardCopyOption.REPLACE_EXISTING);
+				Files.move(oldEncFolder, newEncFolder,
+					StandardCopyOption.REPLACE_EXISTING);
 				Files.createDirectories(oldEncFolder);
-				Files.write(oldEncFolder.resolve("README_MIGRATION.txt"), readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
-			}
-			catch (IOException e){}
-
-		}
-
-
-
+				Files.write(oldEncFolder.resolve("README_MIGRATION.txt"),
+					readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
+			}catch(IOException e)
+			{}
+		
 	}
 	
 	public byte[] decrypt(byte[] bytes)

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -14,6 +14,7 @@ import java.io.ObjectOutputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.io.File;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
@@ -109,8 +110,16 @@ public final class Encryption
 		try
 		{
 			Files.createDirectories(newEncFolder);
-			Files.move(oldEncFolder, newEncFolder,
-				StandardCopyOption.REPLACE_EXISTING);
+			Path newEncFolderFileDestinationPath;
+			File oldEncFolderFiles[] = oldEncFolder.toFile().listFiles();
+			for (int i = 0; i < oldEncFolderFiles.length; i++)
+			{
+				newEncFolderFileDestinationPath = newEncFolder.resolve(oldEncFolderFiles[i].getName());
+				Files.copy(oldEncFolderFiles[i].toPath(), newEncFolderFileDestinationPath);
+				oldEncFolderFiles[i].delete();
+			}
+			Files.deleteIfExists(oldEncFolder);
+
 		}catch(IOException e)
 		{
 			System.out.println("Failed to migrate encryption folder!");

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -110,21 +110,20 @@ public final class Encryption
 			+ newEncFolder.normalize().toString()
 			+ " to comply with XDG base directory, you may safely remove this directory.\r\n";
 		
-		if(!Files.exists(newEncFolder) && Files.exists(oldEncFolder))
-			try
-			{
-				Files.createDirectories(newEncFolder);
-				Files.move(oldEncFolder, newEncFolder,
-					StandardCopyOption.REPLACE_EXISTING);
-				Files.createDirectories(oldEncFolder);
-				Files.write(oldEncFolder.resolve("README_MIGRATION.txt"),
-					readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
+		try
+		{
+			Files.createDirectories(newEncFolder);
+			Files.move(oldEncFolder, newEncFolder,
+				StandardCopyOption.REPLACE_EXISTING);
+			Files.createDirectories(oldEncFolder);
+			Files.write(oldEncFolder.resolve("README_MIGRATION.txt"),
+				readmeText.getBytes("UTF-8"), StandardOpenOption.CREATE);
 				
-			}catch(IOException e)
-			{
-				System.out.println("Failed to migrate encryption folder!");
-				e.printStackTrace();
-			}
+		}catch(IOException e)
+		{
+			System.out.println("Failed to migrate encryption folder!");
+			e.printStackTrace();
+		}
 	}
 	
 	public byte[] decrypt(byte[] bytes)


### PR DESCRIPTION
## Description
Added basic support for XDG base directory, if the environment variable `XDG_DATA_HOME` is set then alts and encryption will be stored in `$XDG_DATA_HOME/WurstClient/`, else it will just store in `.Wurst encryption`, in the home directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a dynamic encryption folder location for the Wurst client. The location is now determined based on the `XDG_DATA_HOME` environment variable, enhancing compatibility with different system configurations.
- Refactor: Added a migration function to handle the transition of the encryption folder from its old location to the new one. This ensures seamless user experience during upgrades.
- Bug Fix: Removed an unused import statement, improving code cleanliness and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->