### PR TITLE
vclip up/down integration with jesus hack #877

### DIFF
--- a/src/main/java/net/wurstclient/commands/VClipCmd.java
+++ b/src/main/java/net/wurstclient/commands/VClipCmd.java
@@ -16,6 +16,7 @@ import net.wurstclient.command.CmdException;
 import net.wurstclient.command.CmdSyntaxError;
 import net.wurstclient.command.Command;
 import net.wurstclient.util.MathUtils;
+import net.wurstclient.WurstClient;
 
 public final class VClipCmd extends Command
 {
@@ -108,5 +109,10 @@ public final class VClipCmd extends Command
 	{
 		ClientPlayerEntity p = MC.player;
 		p.setPosition(p.getX(), p.getY() + height, p.getZ());
+		if(WurstClient.INSTANCE.getHax().jesusHack.isEnabled())
+		{
+			while(WurstClient.INSTANCE.getHax().jesusHack.isOverLiquid())
+				p.setPosition(p.getX(), p.getY() + 1, p.getZ());
+		}
 	}
 }


### PR DESCRIPTION
Solving Issue: #877

## Description
The code now checks if JesusHack is enabled, and if it is, when the .vclip command teleports you into fluids, it relocates you above them.

## (Optional) screenshots / videos
https://github.com/Wurst-Imperium/Wurst7/assets/21334034/e33898cc-c82a-4e54-9353-0ccc3cf2503a
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the "vclip" command in the Wurst Client. When the "jesusHack" feature is enabled, the player's position will now be adjusted to stay above liquid blocks. This improvement provides a smoother and more intuitive user experience when navigating through liquid terrains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->