### PR TITLE
Add new setting to AimAssist `onlyAllowWhileClicking`

### DIFF
--- a/src/main/java/net/wurstclient/hacks/AimAssistHack.java
+++ b/src/main/java/net/wurstclient/hacks/AimAssistHack.java
@@ -48,6 +48,10 @@ public final class AimAssistHack extends Hack
 	private final CheckboxSetting checkLOS = new CheckboxSetting(
 		"Check line of sight", "Won't aim at entities behind blocks.", true);
 	
+	private final CheckboxSetting onlyAllowWhileClicking =
+		new CheckboxSetting("Only allow while clicking",
+			"Won't aim at entities while not clicking.", false);
+	
 	private final EntityFilterList entityFilters =
 		new EntityFilterList(FilterPlayersSetting.genericCombat(false),
 			FilterSleepingSetting.genericCombat(false),
@@ -90,6 +94,7 @@ public final class AimAssistHack extends Hack
 		addSetting(rotationSpeed);
 		addSetting(fov);
 		addSetting(checkLOS);
+		addSetting(onlyAllowWhileClicking);
 		
 		entityFilters.forEach(this::addSetting);
 	}
@@ -126,6 +131,12 @@ public final class AimAssistHack extends Hack
 		if(MC.currentScreen instanceof HandledScreen)
 			return;
 		
+		if(onlyAllowWhileClicking.isChecked()
+			&& !MC.options.attackKey.isPressed())
+		{
+			return;
+		}
+		
 		Stream<Entity> stream = EntityUtils.getAttackableEntities();
 		double rangeSq = Math.pow(range.getValue(), 2);
 		stream = stream.filter(e -> MC.player.squaredDistanceTo(e) <= rangeSq);
@@ -156,6 +167,7 @@ public final class AimAssistHack extends Hack
 	
 	private boolean faceEntityClient(Entity entity)
 	{
+		
 		// get needed rotation
 		Box box = entity.getBoundingBox();
 		Rotation needed = RotationUtils.getNeededRotations(box.getCenter());
@@ -179,7 +191,11 @@ public final class AimAssistHack extends Hack
 	{
 		if(target == null)
 			return;
-			
+		if(onlyAllowWhileClicking.isChecked()
+			&& !MC.options.attackKey.isPressed())
+		{
+			return;
+		}
 		// Not actually rendering anything, just using this method to rotate
 		// more smoothly.
 		float oldYaw = MC.player.prevYaw;


### PR DESCRIPTION
<!-- NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute! -->

## Description
Added a new feature to the codebase: `onlyAllowWhileClicking` CheckboxSetting. When enabled, this setting prevents the aim from targeting entities when the attack key is not pressed.

## Testing
I have tested these changes by enabling the `onlyAllowWhileClicking` setting and verifying that the aim does not target entities when the attack key is not pressed. Additionally, I have checked that the aim behaves as expected when the setting is disabled. I recommend the reviewer to perform similar tests to validate the functionality.

## References
No related issues or forum posts at the moment.
