### PR TITLE
Min Depth Option For Safe Walk Hack

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.15.7
 fabric_version=0.92.0+1.20.1
 
 # Mod Properties
-mod_version = v7.41.1-MC1.20.1
+mod_version = v7.41.1-MC1.20.1-Modified
 maven_group = net.wurstclient
 archives_base_name = Wurst-Client
 

--- a/src/main/java/net/wurstclient/hacks/AutoReconnectHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoReconnectHack.java
@@ -11,6 +11,7 @@ import net.wurstclient.Category;
 import net.wurstclient.DontBlock;
 import net.wurstclient.SearchTags;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
 import net.wurstclient.settings.SliderSetting;
 import net.wurstclient.settings.SliderSetting.ValueDisplay;
 
@@ -18,6 +19,10 @@ import net.wurstclient.settings.SliderSetting.ValueDisplay;
 @DontBlock
 public final class AutoReconnectHack extends Hack
 {
+	private final CheckboxSetting buttons =
+		new CheckboxSetting("Reconnect screen button", "Shows a button on the reconnect"
+			+ " screen that lets you quickly enable AutoReconnect.", true);
+
 	private final SliderSetting waitTime =
 		new SliderSetting("Wait time", "Time before reconnecting in seconds.",
 			5, 0, 60, 0.5, ValueDisplay.DECIMAL.withSuffix("s"));
@@ -26,7 +31,12 @@ public final class AutoReconnectHack extends Hack
 	{
 		super("AutoReconnect");
 		setCategory(Category.OTHER);
+		addSetting(buttons);
 		addSetting(waitTime);
+	}
+
+	public boolean shouldShowButtons() {
+		return buttons.isChecked();
 	}
 	
 	public int getWaitTicks()

--- a/src/main/java/net/wurstclient/hacks/AutoReconnectHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoReconnectHack.java
@@ -19,10 +19,11 @@ import net.wurstclient.settings.SliderSetting.ValueDisplay;
 @DontBlock
 public final class AutoReconnectHack extends Hack
 {
-	private final CheckboxSetting buttons =
-		new CheckboxSetting("Reconnect screen button", "Shows a button on the reconnect"
-			+ " screen that lets you quickly enable AutoReconnect.", true);
-
+	private final CheckboxSetting buttons = new CheckboxSetting(
+		"Reconnect screen button", "Shows a button on the reconnect"
+			+ " screen that lets you quickly enable AutoReconnect.",
+		true);
+	
 	private final SliderSetting waitTime =
 		new SliderSetting("Wait time", "Time before reconnecting in seconds.",
 			5, 0, 60, 0.5, ValueDisplay.DECIMAL.withSuffix("s"));
@@ -34,8 +35,9 @@ public final class AutoReconnectHack extends Hack
 		addSetting(buttons);
 		addSetting(waitTime);
 	}
-
-	public boolean shouldShowButtons() {
+	
+	public boolean shouldShowButtons()
+	{
 		return buttons.isChecked();
 	}
 	

--- a/src/main/java/net/wurstclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientPlayerEntityMixin.java
@@ -269,7 +269,7 @@ public class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 	protected boolean clipAtLedge()
 	{
 		return super.clipAtLedge()
-			|| WurstClient.INSTANCE.getHax().safeWalkHack.isEnabled();
+			|| WurstClient.INSTANCE.getHax().safeWalkHack.shouldClip();
 	}
 	
 	/**
@@ -282,8 +282,7 @@ public class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 		Vec3d result = super.adjustMovementForSneaking(movement, type);
 		
 		if(movement != null)
-			WurstClient.INSTANCE.getHax().safeWalkHack
-				.onClipAtLedge(!movement.equals(result));
+			WurstClient.INSTANCE.getHax().safeWalkHack.onClipAtLedge();
 		
 		return result;
 	}

--- a/src/main/java/net/wurstclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DisconnectedScreenMixin.java
@@ -67,8 +67,8 @@ public class DisconnectedScreenMixin extends Screen
 			client.setScreen(new NcrModRequiredScreen(parent));
 			return;
 		}
-
-		if (WurstClient.INSTANCE.getHax().autoReconnectHack.shouldShowButtons())
+		
+		if(WurstClient.INSTANCE.getHax().autoReconnectHack.shouldShowButtons())
 			addReconnectButtons();
 	}
 	

--- a/src/main/java/net/wurstclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DisconnectedScreenMixin.java
@@ -67,8 +67,9 @@ public class DisconnectedScreenMixin extends Screen
 			client.setScreen(new NcrModRequiredScreen(parent));
 			return;
 		}
-		
-		addReconnectButtons();
+
+		if (WurstClient.INSTANCE.getHax().autoReconnectHack.shouldShowButtons())
+			addReconnectButtons();
 	}
 	
 	private void addReconnectButtons()

--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -79,17 +79,6 @@ public abstract class GameMenuScreenMixin extends Screen
 		context.drawTexture(WURST_TEXTURE, x, y, u, v, w, h, fw, fh);
 	}
 
-	private  boolean isModMenuInstalled() {
-		try {
-			// Attempt to load a class or interface from the other mod
-			Class.forName("com.terraformersmc.modmenu.ModMenu");
-			return true; // The class was found, indicating that the other mod is installed
-		} catch (ClassNotFoundException e) {
-			return false; // The class was not found, indicating that the other mod is not installed
-		}
-	}
-
-
 	private void addWurstOptionsButton()
 	{
 		List<ClickableWidget> buttons = Screens.getButtons(this);
@@ -118,11 +107,11 @@ public abstract class GameMenuScreenMixin extends Screen
 			throw new CrashException(
 				CrashReport.create(new IllegalStateException(),
 					"Someone deleted the Feedback button!"));
-
+		
 		wurstOptionsButton = ButtonWidget
-			.builder(Text.literal("Secret Options"),
+			.builder(Text.literal("            Options"),
 				b -> openWurstOptions())
-			.dimensions(width / 2 - 102, buttonY, isModMenuInstalled() ? 98 : 204, 20).build();
+			.dimensions(width / 2 - 102, buttonY, 204, 20).build();
 		buttons.add(wurstOptionsButton);
 	}
 	

--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -78,7 +78,7 @@ public abstract class GameMenuScreenMixin extends Screen
 		float v = 0;
 		context.drawTexture(WURST_TEXTURE, x, y, u, v, w, h, fw, fh);
 	}
-
+	
 	private void addWurstOptionsButton()
 	{
 		List<ClickableWidget> buttons = Screens.getButtons(this);

--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -78,7 +78,18 @@ public abstract class GameMenuScreenMixin extends Screen
 		float v = 0;
 		context.drawTexture(WURST_TEXTURE, x, y, u, v, w, h, fw, fh);
 	}
-	
+
+	private  boolean isModMenuInstalled() {
+		try {
+			// Attempt to load a class or interface from the other mod
+			Class.forName("com.terraformersmc.modmenu.ModMenu");
+			return true; // The class was found, indicating that the other mod is installed
+		} catch (ClassNotFoundException e) {
+			return false; // The class was not found, indicating that the other mod is not installed
+		}
+	}
+
+
 	private void addWurstOptionsButton()
 	{
 		List<ClickableWidget> buttons = Screens.getButtons(this);
@@ -107,11 +118,11 @@ public abstract class GameMenuScreenMixin extends Screen
 			throw new CrashException(
 				CrashReport.create(new IllegalStateException(),
 					"Someone deleted the Feedback button!"));
-		
+
 		wurstOptionsButton = ButtonWidget
-			.builder(Text.literal("Sweet Options"),
+			.builder(Text.literal("Secret Options"),
 				b -> openWurstOptions())
-			.dimensions(width / 2 - 102, buttonY, 204, 20).build();
+			.dimensions(width / 2 - 102, buttonY, isModMenuInstalled() ? 98 : 204, 20).build();
 		buttons.add(wurstOptionsButton);
 	}
 	

--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -109,7 +109,7 @@ public abstract class GameMenuScreenMixin extends Screen
 					"Someone deleted the Feedback button!"));
 		
 		wurstOptionsButton = ButtonWidget
-			.builder(Text.literal("            Options"),
+			.builder(Text.literal("Sweet Options"),
 				b -> openWurstOptions())
 			.dimensions(width / 2 - 102, buttonY, 204, 20).build();
 		buttons.add(wurstOptionsButton);


### PR DESCRIPTION
# Min Depth Option For Safe Walk Hack

In this pull request, I've added a `Min depth` option for the hack `SafeWalk`, making this hack better because you will no longer be sneaking on a stair, really annoying.

> [!NOTE]
> I only made for Minecraft 1.20.1, most of the modpack is on this version I think.

> [!WARNING]
> I know nearly nothing about those anti-cheat mods/plugins and haven't tested any of them, so use at your own risk.
> As far as I know, the modified version of `SafeWalk` is not suspicious at all, though

## How It Work

How it originally work:
1. In `ClientPlayerEntityMixin.java`, the hack add a condition to `clipAtLedge()` method, so whenever the hack is enabled, the player will always keep you on the ledge.
2. In `SafeWalkHack.java`, it checks if the adjusted (by `Edge distance` option) player bounding box is empty, if so, make the player sneak.

It's not gonna work if I only adjust the bounding box, because the player will still clip at ledge, checking the bounding box on `clipAtLedge()` will lead to another problem too: it would wait until the bounding box is emptied, but then it's too late, the player already leaved the ledge.

So, I must make a motion prediction, if `bounding box + velocity` is going straight to a ledge, then clip!

How it work, modified version:
1. Use the custom-height bounding box 
1. If `bounding box + velocity` is empty, clip at ledge.
2. sneak, same condition as the original.

I also added a option named `Motion prediction`, it's the modifier of how much motion should be take as reference (But I don't know why, it does not differ a lot.)

Hope this helps!

---

P.S. Wurst API is so great :)
P.S. Why spotless check :(