### PR TITLE
Add SafeWalk Min Depth Option Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.15.7
 fabric_version=0.92.0+1.20.1
 
 # Mod Properties
-mod_version = v7.41.1-MC1.20.1
+mod_version = v7.41.1-MC1.20.1-Modified
 maven_group = net.wurstclient
 archives_base_name = Wurst-Client
 

--- a/src/main/java/net/wurstclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientPlayerEntityMixin.java
@@ -269,7 +269,7 @@ public class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 	protected boolean clipAtLedge()
 	{
 		return super.clipAtLedge()
-			|| WurstClient.INSTANCE.getHax().safeWalkHack.isEnabled();
+			|| WurstClient.INSTANCE.getHax().safeWalkHack.shouldClip();
 	}
 	
 	/**
@@ -282,8 +282,7 @@ public class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 		Vec3d result = super.adjustMovementForSneaking(movement, type);
 		
 		if(movement != null)
-			WurstClient.INSTANCE.getHax().safeWalkHack
-				.onClipAtLedge(!movement.equals(result));
+			WurstClient.INSTANCE.getHax().safeWalkHack.onClipAtLedge();
 		
 		return result;
 	}


### PR DESCRIPTION
# Min Depth Option For Safe Walk Hack

In this pull request, I've added a `Min depth` option for the hack `SafeWalk`, making this hack better because you will no longer be sneaking on a stair, really annoying.

> [!NOTE]
> I only made for Minecraft 1.20.1, most of the modpack is on this version I think.

> [!WARNING]
> I know nearly nothing about those anti-cheat mods/plugins and haven't tested any of them, so use at your own risk.
> As far as I know, the modified version of `SafeWalk` is not suspicious at all, though

## How It Works

How it originally worked:
1. In `ClientPlayerEntityMixin.java`, the hack add a condition to `clipAtLedge()` method, so whenever the hack is enabled, the player will always keep you on the ledge.
2. In `SafeWalkHack.java`, it checks if the adjusted (by `Edge distance` option) player bounding box is empty, if so, make the player sneak.

It's not gonna work if I only adjust the bounding box, because the player will still clip at ledge, checking the bounding box on `clipAtLedge()` will lead to another problem too: it would wait until the bounding box is emptied, but then it's too late, the player already leaved the ledge.

So, I must make a motion prediction, if `bounding box + velocity` is going straight to a ledge, then clip!

How it work, modified version:
1. Use the custom-height bounding box 
1. If `bounding box + velocity` is empty, clip at ledge.
2. sneak, same condition as the original.

I also added a option named `Motion prediction`, it's the modifier of how much motion should be take as reference (But I don't know why, it does not differ a lot.)

Hope this helps!

---

P.S. Wurst API is so great :)
P.S. Why spotless check :(