### PR TITLE
Separate Hoglins from Passive Mob

### DIFF
--- a/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
@@ -72,6 +72,7 @@ public class EntityFilterList
 			FilterBabiesSetting.genericCombat(false),
 			FilterBatsSetting.genericCombat(false),
 			FilterSlimesSetting.genericCombat(false),
+			FilterHoglinsSetting.genericCombat(false),
 			FilterPetsSetting.genericCombat(false),
 			FilterVillagersSetting.genericCombat(false),
 			FilterZombieVillagersSetting.genericCombat(false),

--- a/src/main/java/net/wurstclient/settings/filters/FilterHoglinsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterHoglinsSetting.java
@@ -1,0 +1,25 @@
+package net.wurstclient.settings.filters;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.Hoglin;
+
+public class FilterHoglinsSetting extends EntityFilterCheckbox {
+	public FilterHoglinsSetting(String description, boolean checked) {
+		super("Filter hoglins", description, checked);
+	}
+
+	@Override
+	public boolean test(Entity e) {
+		return !(e instanceof Hoglin);
+	}
+
+	public static FilterHoglinsSetting genericCombat(boolean checked) {
+		return new FilterHoglinsSetting(
+			"Won't attack hoglins.", checked);
+	}
+
+	public static FilterHoglinsSetting genericVision(boolean checked) {
+		return new FilterHoglinsSetting(
+			"Won't show hoglins.", checked);
+	}
+}

--- a/src/main/java/net/wurstclient/settings/filters/FilterPassiveSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPassiveSetting.java
@@ -10,6 +10,7 @@ package net.wurstclient.settings.filters;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.AmbientEntity;
 import net.minecraft.entity.mob.Angerable;
+import net.minecraft.entity.mob.Hoglin;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.passive.PufferfishEntity;
@@ -28,7 +29,8 @@ public final class FilterPassiveSetting extends EntityFilterCheckbox
 	public boolean test(Entity e)
 	{
 		// never filter out neutral mobs (including pufferfish)
-		if(e instanceof Angerable || e instanceof PufferfishEntity)
+		// never hoglins, too!
+		if (e instanceof Angerable || e instanceof PufferfishEntity || e instanceof Hoglin)
 			return true;
 		
 		return !(e instanceof AnimalEntity || e instanceof AmbientEntity


### PR DESCRIPTION
# Separate Hoglins from Passive Mob

In `EntityFilterList.java`, there's some entity filter for combat/vision purposes. But for some reason hoglins are consider as passive mobs. That should be a glitch, because hoglins will attack players, not passive at all.

So, I've modified the `FilterPassiveSettings` to exclude hoglins, and add a new option: `Filter hoglins`.