### PR TITLE
Added option for guide boxes to show where airplace will place blocks

### DIFF
--- a/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
+++ b/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
@@ -32,10 +32,9 @@ import net.wurstclient.util.InteractionSimulator;
 import net.wurstclient.util.RegionPos;
 import net.wurstclient.util.RenderUtils;
 
-
 @SearchTags({"air place"})
-public final class AirPlaceHack extends Hack implements RightClickListener,
-	UpdateListener, RenderListener
+public final class AirPlaceHack extends Hack
+	implements RightClickListener, UpdateListener, RenderListener
 {
 	private final SliderSetting range =
 		new SliderSetting("Range", 5, 1, 6, 0.05, ValueDisplay.DECIMAL);
@@ -94,7 +93,8 @@ public final class AirPlaceHack extends Hack implements RightClickListener,
 	@Override
 	public void onRender(MatrixStack matrixStack, float partialTicks)
 	{
-		if (guide.isChecked() && bp != null) {
+		if(guide.isChecked() && bp != null)
+		{
 			// GL settings
 			GL11.glEnable(GL11.GL_BLEND);
 			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
@@ -121,27 +121,29 @@ public final class AirPlaceHack extends Hack implements RightClickListener,
 		RegionPos region)
 	{
 		matrixStack.push();
-			
+		
 		float[] colorF = color.getColorF();
 		matrixStack.translate(bp.getX(), bp.getY(), bp.getZ());
-
-	    RenderSystem.setShaderColor(colorF[0], colorF[1], colorF[2], 0.2F);
-   
-	    Box bb = new Box(0, 0, 0, 1, 1, 1);
-	        
-	    RenderUtils.drawSolidBox(bb, matrixStack);
-        RenderSystem.setShaderColor(colorF[0], colorF[1], colorF[2], 1F);
-        RenderUtils.drawOutlinedBox(bb, matrixStack);
-        
-        matrixStack.pop();
+		
+		RenderSystem.setShaderColor(colorF[0], colorF[1], colorF[2], 0.2F);
+		
+		Box bb = new Box(0, 0, 0, 1, 1, 1);
+		
+		RenderUtils.drawSolidBox(bb, matrixStack);
+		RenderSystem.setShaderColor(colorF[0], colorF[1], colorF[2], 1F);
+		RenderUtils.drawOutlinedBox(bb, matrixStack);
+		
+		matrixStack.pop();
 	}
 	
 	@Override
 	public void onUpdate()
 	{
 		HitResult hitResult = MC.player.raycast(range.getValue(), 0, false);
-		if(hitResult.getType() != HitResult.Type.MISS) {
-			bp = null; // dont draw if looking at non-airplace location like ground
+		if(hitResult.getType() != HitResult.Type.MISS)
+		{
+			bp = null; // dont draw if looking at non-airplace location like
+						// ground
 			return;
 		}
 		

--- a/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
+++ b/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
@@ -7,38 +7,69 @@
  */
 package net.wurstclient.hacks;
 
+import java.awt.Color;
+
+import org.lwjgl.opengl.GL11;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
+import net.wurstclient.events.RenderListener;
 import net.wurstclient.events.RightClickListener;
+import net.wurstclient.events.UpdateListener;
 import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
+import net.wurstclient.settings.ColorSetting;
 import net.wurstclient.settings.SliderSetting;
 import net.wurstclient.settings.SliderSetting.ValueDisplay;
 import net.wurstclient.util.InteractionSimulator;
+import net.wurstclient.util.RegionPos;
+import net.wurstclient.util.RenderUtils;
+
 
 @SearchTags({"air place"})
-public final class AirPlaceHack extends Hack implements RightClickListener
+public final class AirPlaceHack extends Hack implements RightClickListener,
+	UpdateListener, RenderListener
 {
 	private final SliderSetting range =
 		new SliderSetting("Range", 5, 1, 6, 0.05, ValueDisplay.DECIMAL);
+	
+	private final ColorSetting color = new ColorSetting("Color",
+		"Block placing guide will be highlighted in this color.", Color.RED);
+	
+	private final CheckboxSetting guide = new CheckboxSetting("Guide",
+		"Shows a guide for where blocks will place", true);
+	
+	private BlockPos bp;
 	
 	public AirPlaceHack()
 	{
 		super("AirPlace");
 		setCategory(Category.BLOCKS);
 		addSetting(range);
+		addSetting(color);
+		addSetting(guide);
 	}
 	
 	@Override
 	protected void onEnable()
 	{
+		EVENTS.add(UpdateListener.class, this);
+		EVENTS.add(RenderListener.class, this);
 		EVENTS.add(RightClickListener.class, this);
 	}
 	
 	@Override
 	protected void onDisable()
 	{
+		EVENTS.remove(UpdateListener.class, this);
+		EVENTS.remove(RenderListener.class, this);
 		EVENTS.remove(RightClickListener.class, this);
 	}
 	
@@ -58,5 +89,65 @@ public final class AirPlaceHack extends Hack implements RightClickListener
 		
 		InteractionSimulator.rightClickBlock(blockHitResult);
 		event.cancel();
+	}
+	
+	@Override
+	public void onRender(MatrixStack matrixStack, float partialTicks)
+	{
+		if (guide.isChecked() && bp != null) {
+			// GL settings
+			GL11.glEnable(GL11.GL_BLEND);
+			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+			GL11.glDisable(GL11.GL_CULL_FACE);
+			GL11.glDisable(GL11.GL_DEPTH_TEST);
+			
+			matrixStack.push();
+			
+			RegionPos region = RenderUtils.getCameraRegion();
+			RenderUtils.applyRegionalRenderOffset(matrixStack, region);
+			
+			renderBoxes(matrixStack, partialTicks, region);
+			
+			matrixStack.pop();
+			
+			// GL resets
+			RenderSystem.setShaderColor(1, 1, 1, 1);
+			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GL11.glDisable(GL11.GL_BLEND);
+		}
+	}
+	
+	private void renderBoxes(MatrixStack matrixStack, float partialTicks,
+		RegionPos region)
+	{
+		matrixStack.push();
+			
+		float[] colorF = color.getColorF();
+		matrixStack.translate(bp.getX(), bp.getY(), bp.getZ());
+
+	    RenderSystem.setShaderColor(colorF[0], colorF[1], colorF[2], 0.2F);
+   
+	    Box bb = new Box(0, 0, 0, 1, 1, 1);
+	        
+	    RenderUtils.drawSolidBox(bb, matrixStack);
+        RenderSystem.setShaderColor(colorF[0], colorF[1], colorF[2], 1F);
+        RenderUtils.drawOutlinedBox(bb, matrixStack);
+        
+        matrixStack.pop();
+	}
+	
+	@Override
+	public void onUpdate()
+	{
+		HitResult hitResult = MC.player.raycast(range.getValue(), 0, false);
+		if(hitResult.getType() != HitResult.Type.MISS) {
+			bp = null; // dont draw if looking at non-airplace location like ground
+			return;
+		}
+		
+		if(!(hitResult instanceof BlockHitResult blockHitResult))
+			return;
+		
+		bp = blockHitResult.getBlockPos();
 	}
 }

--- a/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
+++ b/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
@@ -41,10 +41,10 @@ public final class AirPlaceHack extends Hack
 		new SliderSetting("Range", 5, 1, 6, 0.05, ValueDisplay.DECIMAL);
 	
 	private final CheckboxSetting guide = new CheckboxSetting("Guide",
-		"Shows a guide for where blocks will be placed.", true);
+		"description.wurst.setting.airplace.guide", true);
 	
 	private final ColorSetting guideColor = new ColorSetting("Guide color",
-		"Color of the block placing guide, if enabled.", Color.RED);
+		"description.wurst.setting.airplace.guide_color", Color.RED);
 	
 	private BlockPos renderPos;
 	

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -1,6 +1,8 @@
 {
   "description.wurst.hack.aimassist": "Helps you aim at nearby entities.",
   "description.wurst.hack.airplace": "Allows you to place blocks in mid-air.",
+  "description.wurst.setting.airplace.guide": "Shows a guide for where blocks will be placed.",
+  "description.wurst.setting.airplace.guide_color": "Color of the block placing guide, if enabled.",
   "description.wurst.hack.anchoraura": "Automatically places (optional), charges, and detonates respawn anchors to kill entities around you.",
   "description.wurst.hack.antiafk": "Walks around randomly to hide you from AFK detectors.",
   "description.wurst.hack.antiblind": "Prevents blindness and darkness effects.\nIncompatible with OptiFine.",


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
> What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)

Added optional guide boxes for airplace hack to show where the block will be placed (off by default)
Sort of fix/feature for https://github.com/Wurst-Imperium/Wurst7/issues/1014 but more just qol

## Testing
> How have you tested your changes? Any testing tips for the reviewer?

Tested multiplayer and singleplayer, with different colors, ranges, and other render-related hacks

## References
> List any related issues, forum posts, videos and such here.

https://youtu.be/chV8J5KHzuQ