### PR TITLE
Fix TriggerBotHack NPE

### DIFF
--- a/src/main/java/net/wurstclient/hacks/TriggerBotHack.java
+++ b/src/main/java/net/wurstclient/hacks/TriggerBotHack.java
@@ -136,6 +136,9 @@ public final class TriggerBotHack extends Hack
 	@Override
 	public void onHandleInput()
 	{
+		if(MC.player == null)
+			return;
+		
 		speed.updateTimer();
 		if(!speed.isTimeToAttack())
 			return;


### PR DESCRIPTION
## Description
Fixed NPE produced in `TriggerBotHack` when leaving a server.
Most likely introduced in a recent commit that changed `HandleInputEvent` injection point (0d50ef6)

## References
https://github.com/user-attachments/assets/c3a15b11-520e-45bc-aad2-d355470d9f47
