### PR TITLE
Add TeamEspHack

### DIFF
--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -172,6 +172,7 @@ public final class HackList implements UpdateListener
 	public final SpeedNukerHack speedNukerHack = new SpeedNukerHack();
 	public final SpiderHack spiderHack = new SpiderHack();
 	public final StepHack stepHack = new StepHack();
+	public final TeamEspHack teamEspHack = new TeamEspHack();
 	public final TemplateToolHack templateToolHack = new TemplateToolHack();
 	public final ThrowHack throwHack = new ThrowHack();
 	public final TillauraHack tillauraHack = new TillauraHack();

--- a/src/main/java/net/wurstclient/hacks/AimAssistHack.java
+++ b/src/main/java/net/wurstclient/hacks/AimAssistHack.java
@@ -60,6 +60,8 @@ public final class AimAssistHack extends Hack
 	
 	private final EntityFilterList entityFilters =
 		new EntityFilterList(FilterPlayersSetting.genericCombat(false),
+			FilterTeammatesSetting.genericCombat(false),
+			FilterNpcLikeSetting.genericCombat(false),
 			FilterSleepingSetting.genericCombat(false),
 			FilterFlyingSetting.genericCombat(0),
 			FilterHostileSetting.genericCombat(false),

--- a/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
@@ -62,6 +62,7 @@ public class EntityFilterList
 	public static EntityFilterList genericCombat()
 	{
 		return new EntityFilterList(FilterPlayersSetting.genericCombat(false),
+			FilterNpcLikeSetting.genericCombat(false),
 			FilterSleepingSetting.genericCombat(false),
 			FilterFlyingSetting.genericCombat(0),
 			FilterHostileSetting.genericCombat(false),

--- a/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
@@ -62,6 +62,7 @@ public class EntityFilterList
 	public static EntityFilterList genericCombat()
 	{
 		return new EntityFilterList(FilterPlayersSetting.genericCombat(false),
+			FilterTeammatesSetting.genericCombat(false),
 			FilterNpcLikeSetting.genericCombat(false),
 			FilterSleepingSetting.genericCombat(false),
 			FilterFlyingSetting.genericCombat(0),

--- a/src/main/java/net/wurstclient/settings/filters/FilterNpcLikeSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterNpcLikeSetting.java
@@ -1,0 +1,68 @@
+package net.wurstclient.settings.filters;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+
+public final class FilterNpcLikeSetting extends EntityFilterCheckbox
+{
+	public FilterNpcLikeSetting(String description, boolean checked)
+	{
+		super("Filter NPC-like", description, checked);
+	}
+	
+	@Override
+	public boolean test(Entity e)
+	{
+		if(!(e instanceof PlayerEntity))
+			return true;
+		
+		String name = e.getName().getString();
+		if(name.length() != 10)
+			return true;
+		
+		int letters = 0, digits = 0, maxLetters = 0, maxDigits = 0;
+		for(int c : name.chars().toArray())
+		{
+			if(Character.isDigit(c))
+			{
+				letters = 0;
+				digits += 1;
+			}else if(Character.isLetter(c) && Character.isLowerCase(c))
+			{
+				digits = 0;
+				letters += 1;
+			}else
+			{
+				return true;
+			}
+			
+			if(letters > maxLetters)
+				maxLetters = letters;
+			if(digits > maxDigits)
+				maxDigits = digits;
+		}
+		
+		if(maxDigits == 0)
+			return true;
+		if(maxLetters >= 4 && maxDigits >= 4)
+			return true;
+		if(maxLetters >= 5)
+			return true;
+		
+		return false;
+	}
+	
+	public static FilterNpcLikeSetting genericCombat(boolean checked)
+	{
+		return new FilterNpcLikeSetting(
+			"Won't attack NPC-like players (Sort by Hypixel NPC names.)",
+			checked);
+	}
+	
+	public static FilterNpcLikeSetting genericVision(boolean checked)
+	{
+		return new FilterNpcLikeSetting(
+			"Won't show NPC-like players (Sort by Hypixel NPC names.)",
+			checked);
+	}
+}

--- a/src/main/java/net/wurstclient/settings/filters/FilterTeammatesSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterTeammatesSetting.java
@@ -1,0 +1,47 @@
+package net.wurstclient.settings.filters;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.text.Text;
+import net.minecraft.text.TextColor;
+import net.wurstclient.WurstClient;
+
+public final class FilterTeammatesSetting extends EntityFilterCheckbox
+{
+	public FilterTeammatesSetting(String description, boolean checked)
+	{
+		super("Filter teammates", description, checked);
+	}
+	
+	@Override
+	public boolean test(Entity e)
+	{
+		Text theirName = e.getDisplayName();
+		if(theirName == null)
+			return false;
+		TextColor theirColor = theirName.getStyle().getColor();
+		if(theirColor == null)
+			return false;
+		
+		assert WurstClient.MC.player != null;
+		Text myName = WurstClient.MC.player.getDisplayName();
+		if(myName == null)
+			return false;
+		TextColor myColor = myName.getStyle().getColor();
+		if(myColor == null)
+			return false;
+		
+		return !theirColor.equals(myColor);
+	}
+	
+	public static FilterTeammatesSetting genericCombat(boolean checked)
+	{
+		return new FilterTeammatesSetting(
+			"Won't attack players with the same name tag color.", checked);
+	}
+	
+	public static FilterTeammatesSetting genericVision(boolean checked)
+	{
+		return new FilterTeammatesSetting(
+			"Won't show players with the same name tag color.", checked);
+	}
+}

--- a/src/main/resources/assets/wurst/translations/en_us.json
+++ b/src/main/resources/assets/wurst/translations/en_us.json
@@ -208,6 +208,7 @@
   "description.wurst.hack.spider": "Allows you to climb up walls like a spider.",
   "description.wurst.hack.step": "Allows you to step up full blocks.",
   "description.wurst.hack.templatetool": "Allows you to create custom templates for AutoBuild by scanning existing buildings.",
+  "description.wurst.hack.teamesp": "Highlights nearby teammates/enemies.\nESP boxes will appear in the same color of their name tag.",
   "description.wurst.hack.throw": "Uses an item multiple times. Can be used to throw snowballs and eggs, spawn mobs, place minecarts, etc. in very large quantities.\n\nThis can cause a lot of lag and even crash a server.",
   "description.wurst.hack.tillaura": "Automatically turns dirt, grass, etc. into farmland.\nNot to be confused with Killaura.",
   "description.wurst.hack.timer": "Changes the speed of almost everything.",

--- a/src/main/resources/assets/wurst/translations/zh_tw.json
+++ b/src/main/resources/assets/wurst/translations/zh_tw.json
@@ -143,6 +143,7 @@
   "description.wurst.hack.step": "允許你走上更高高度（取決於你的設定）的格子方塊。",
   "description.wurst.hack.throw": "迅速丟你手中種類的物品，可以用於丟雪球、雞蛋、刷怪蛋、礦車，諸如此類。\n\n會生成大量的數量，這會產生大量的lag且可能會導致服務器崩潰。",
   "description.wurst.hack.tillaura": "自動將泥土、草塊、諸如此類。轉化為耕地。\n不要和Killaura搞混。",
+  "description.wurst.hack.teamesp": "高亮透視附近的隊友或敵人。\n會顯示跟他們的名字標籤同樣顏色的框框。",
   "description.wurst.hack.timer": "改變大部分東西的速度。",
   "description.wurst.hack.tired": "讓你看起來很像2015年的Alexander。\n僅限其他玩家可視。",
   "description.wurst.hack.toomanyhax": "關閉那些你並不想要使用的功能。\n讓你確保你不會不小心開啟錯誤的作弊功能導致被服務器封禁。\n這個是給那些“只想作弊一點點的用戶”。\n\n使用指令§6. toomanyhax§r來選擇哪些功能需要被遮罩。\n輸入§6. help toomanyhax§r尋求更多。",


### PR DESCRIPTION
## Description

Added a simple but cool feature, `TeamEsp`. It's basically just `PlayerEsp` but using the color of their name tags.

## Testing

![image](https://github.com/user-attachments/assets/eb8644b2-8fc7-489e-be28-914626210df8)

## Additional Stuff

### NPC Filtering

I also added a feature called `FilterNpcLikeSetting` because the white boxes on NPCs were annoying, as it loses the meaning of using `TeamESP`.

But I can't think of a good way to detect NPCs, so now it will only check the name patterns that NPCs will appear in Hypixel.

### Teammates Filtering

It's weird to constantly target and attack your teammates, so I added `FilterTeamates` to ignore hem