### PR TITLE
ProfileKeys fix

### DIFF
--- a/src/main/java/net/wurstclient/altmanager/MicrosoftLoginManager.java
+++ b/src/main/java/net/wurstclient/altmanager/MicrosoftLoginManager.java
@@ -104,7 +104,7 @@ public enum MicrosoftLoginManager
 		
 		Session session = new Session(mcProfile.getName(), mcProfile.getUUID(),
 			mcProfile.getAccessToken(), Optional.empty(), Optional.empty(),
-			Session.AccountType.MOJANG);
+			Session.AccountType.MSA);
 		
 		WurstClient.IMC.setSession(session);
 	}

--- a/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
@@ -8,7 +8,6 @@
 package net.wurstclient.mixin;
 
 import java.io.File;
-import java.util.UUID;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,7 +26,6 @@ import net.minecraft.client.WindowEventHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.session.ProfileKeys;
-import net.minecraft.client.session.ProfileKeysImpl;
 import net.minecraft.client.session.Session;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.hit.HitResult;
@@ -59,7 +57,7 @@ public abstract class MinecraftClientMixin
 	private YggdrasilAuthenticationService authenticationService;
 	
 	private Session wurstSession;
-	private ProfileKeysImpl wurstProfileKeys;
+	private ProfileKeys wurstProfileKeys;
 	
 	private MinecraftClientMixin(WurstClient wurst, String name)
 	{
@@ -213,10 +211,12 @@ public abstract class MinecraftClientMixin
 	{
 		wurstSession = session;
 		
-		UserApiService userApiService = authenticationService
-			.createUserApiService(session.getAccessToken());
-		UUID uuid = wurstSession.getUuidOrNull();
+		UserApiService userApiService =
+			session.getAccountType() == Session.AccountType.MSA
+				? authenticationService.createUserApiService(
+					session.getAccessToken())
+				: UserApiService.OFFLINE;
 		wurstProfileKeys =
-			new ProfileKeysImpl(userApiService, uuid, runDirectory.toPath());
+			ProfileKeys.create(userApiService, session, runDirectory.toPath());
 	}
 }


### PR DESCRIPTION
Fixes #1068.

This PR only creates the ProfileKeys if the user is logged in to a Microsoft account. This is the way it is done in the vanilla code.