### PR TITLE
Preserve item ordering when clicking "steal" button

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ShulkerBoxScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ShulkerBoxScreenMixin.java
@@ -61,7 +61,7 @@ public abstract class ShulkerBoxScreenMixin
 	
 	private void steal()
 	{
-		runInThread(() -> shiftClickSlots(0, rows * 9, 1));
+		runInThread(() -> shiftClickSlots(rows * 9, 0, 1));
 	}
 	
 	private void store()
@@ -87,7 +87,7 @@ public abstract class ShulkerBoxScreenMixin
 	{
 		this.mode = mode;
 		
-		for(int i = from; i < to; i++)
+		for(int i = from; i != to; i += i < to ? 1 : -1)
 		{
 			Slot slot = handler.slots.get(i);
 			if(slot.getStack().isEmpty())


### PR DESCRIPTION
🙏🥺 Humble 2b2t map artist, trying to make bulk copying just a little bit easier by not having the order of items get reversed when they are taken from a shulker using the "steal" button. This lets me "steal", copy, and "store" map art (and ordered items in general, e.g. series of written books) with much less hassle.