### PR TITLE
Add squids/dolphins back to passive mob filters

### DIFF
--- a/src/main/java/net/wurstclient/clickgui/components/RadarComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/RadarComponent.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.mob.AmbientEntity;
 import net.minecraft.entity.mob.Monster;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.WaterAnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -114,7 +115,8 @@ public final class RadarComponent extends Component
 		if(e instanceof Monster)
 			return 0xFFFF8000;
 		if(e instanceof AnimalEntity || e instanceof AmbientEntity
-			|| e instanceof WaterCreatureEntity)
+			|| e instanceof WaterCreatureEntity
+			|| e instanceof WaterAnimalEntity)
 			return 0xFF00FF00;
 		return 0xFF808080;
 	}

--- a/src/main/java/net/wurstclient/settings/filters/FilterPassiveSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPassiveSetting.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.mob.Monster;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.passive.PufferfishEntity;
+import net.minecraft.entity.passive.WaterAnimalEntity;
 
 public final class FilterPassiveSetting extends EntityFilterCheckbox
 {
@@ -37,7 +38,8 @@ public final class FilterPassiveSetting extends EntityFilterCheckbox
 			return true;
 		
 		return !(e instanceof AnimalEntity || e instanceof AmbientEntity
-			|| e instanceof WaterCreatureEntity);
+			|| e instanceof WaterCreatureEntity
+			|| e instanceof WaterAnimalEntity);
 	}
 	
 	public static FilterPassiveSetting genericCombat(boolean checked)

--- a/src/main/java/net/wurstclient/settings/filters/FilterPassiveWaterSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPassiveWaterSetting.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.AxolotlEntity;
 import net.minecraft.entity.passive.PufferfishEntity;
+import net.minecraft.entity.passive.WaterAnimalEntity;
 
 public final class FilterPassiveWaterSetting extends EntityFilterCheckbox
 {
@@ -31,7 +32,7 @@ public final class FilterPassiveWaterSetting extends EntityFilterCheckbox
 			return true;
 		
 		return !(e instanceof WaterCreatureEntity
-			|| e instanceof AxolotlEntity);
+			|| e instanceof WaterAnimalEntity || e instanceof AxolotlEntity);
 	}
 	
 	public static FilterPassiveWaterSetting genericCombat(boolean checked)


### PR DESCRIPTION
Needed because the respective mob classes don't extend WaterCreatureEntity in the latest versions (1.21.1 is not affected).