### PR TITLE
Fix ChatInputEvent message assignment

### DIFF
--- a/src/main/java/net/wurstclient/mixin/ChatHudMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ChatHudMixin.java
@@ -39,12 +39,14 @@ public class ChatHudMixin
 	@Inject(at = @At("HEAD"),
 		method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;Lnet/minecraft/client/gui/hud/MessageIndicator;)V",
 		cancellable = true)
-	private void onAddMessage(Text message,
+	private void onAddMessage(Text messageDontUse,
 		@Nullable MessageSignatureData signature,
 		@Nullable MessageIndicator indicatorDontUse, CallbackInfo ci,
-		@Local LocalRef<MessageIndicator> indicator)
+		@Local(argsOnly = true) LocalRef<Text> message,
+		@Local(argsOnly = true) LocalRef<MessageIndicator> indicator)
 	{
-		ChatInputEvent event = new ChatInputEvent(message, visibleMessages);
+		ChatInputEvent event =
+			new ChatInputEvent(message.get(), visibleMessages);
 		
 		EventManager.fire(event);
 		if(event.isCancelled())
@@ -53,8 +55,8 @@ public class ChatHudMixin
 			return;
 		}
 		
-		message = event.getComponent();
+		message.set(event.getComponent());
 		indicator.set(WurstClient.INSTANCE.getOtfs().noChatReportsOtf
-			.modifyIndicator(message, signature, indicator.get()));
+			.modifyIndicator(message.get(), signature, indicator.get()));
 	}
 }


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
Previously, the modified message from `ChatInputEvent` would not be reassigned correctly in `ChatHudMixin` after it was modified.
Only `AntiSpamHack` was affected by this issue.