### PR TITLE
Fix component commands

### DIFF
--- a/src/main/java/net/wurstclient/commands/ModifyCmd.java
+++ b/src/main/java/net/wurstclient/commands/ModifyCmd.java
@@ -78,15 +78,14 @@ public final class ModifyCmd extends Command
 		if(args.length < 3)
 			throw new CmdSyntaxError();
 		
-		ComponentType<?> type =
-			Registries.DATA_COMPONENT_TYPE.get(Identifier.tryParse(args[1]));
+		ComponentType<?> type = parseComponentType(args[1]);
 		
 		String valueString =
 			String.join(" ", Arrays.copyOfRange(args, 2, args.length))
 				.replace("$", "\u00a7").replace("\u00a7\u00a7", "$");
 		JsonElement valueJson = parseJson(valueString);
-		DataResult<?> valueResult =
-			type.getCodec().parse(JsonOps.INSTANCE, valueJson);
+		DataResult<?> valueResult = type.getCodec().parse(
+			MC.player.getRegistryManager().getOps(JsonOps.INSTANCE), valueJson);
 		Object value = valueResult.resultOrPartial().orElse(null);
 		
 		ComponentMap.Builder builder = ComponentMap.builder();
@@ -99,14 +98,19 @@ public final class ModifyCmd extends Command
 		if(args.length > 2)
 			throw new CmdSyntaxError();
 		
+		stack.set(parseComponentType(args[1]), null);
+	}
+	
+	private ComponentType<?> parseComponentType(String typeName) throws CmdError
+	{
 		ComponentType<?> type =
-			Registries.DATA_COMPONENT_TYPE.get(Identifier.tryParse(args[1]));
+			Registries.DATA_COMPONENT_TYPE.get(Identifier.tryParse(typeName));
 		
 		if(type == null)
 			throw new CmdError(
-				"Component type \"" + args[1] + "\" does not exist.");
+				"Component type \"" + typeName + "\" does not exist.");
 		
-		stack.set(type, null);
+		return type;
 	}
 	
 	private JsonElement parseJson(String jsonString) throws CmdError

--- a/src/main/java/net/wurstclient/commands/ViewCompCmd.java
+++ b/src/main/java/net/wurstclient/commands/ViewCompCmd.java
@@ -82,7 +82,8 @@ public final class ViewCompCmd extends Command
 		{
 			compString +=
 				"\n" + c.type().toString().replace("minecraft:", "") + " => ";
-			DataResult<JsonElement> result = c.encode(JsonOps.INSTANCE);
+			DataResult<JsonElement> result = c.encode(
+				MC.player.getRegistryManager().getOps(JsonOps.INSTANCE));
 			JsonElement json =
 				result.resultOrPartial().orElse(JsonNull.INSTANCE);
 			compString += JsonUtils.GSON.toJson(json).replace("$", "$$")


### PR DESCRIPTION
## Description
`ModifyCmd` and `ViewCompCmd` did not work for some component types because Ops should be accessed via registry manager.
`ModifyCmd` also lacked a null check in `set`.

## Testing - examples

### `.modify set enchantments {efficiency:3}`
Before fix:
```
Result: DataResult.Error['Can't access registry ResourceKey[minecraft:root / minecraft:enchantment] missed input: {"efficiency":3}': ItemEnchantments{enchantments={}}]
Value: ItemEnchantments{enchantments={}}
```
After fix:
```
Result: DataResult.Success[ItemEnchantments{enchantments={Reference{ResourceKey[minecraft:enchantment / minecraft:efficiency]=Enchantment Efficiency}=>3}}]
Value: ItemEnchantments{enchantments={Reference{ResourceKey[minecraft:enchantment / minecraft:efficiency]=Enchantment Efficiency}=>3}}
```

### `.viewcomp copy`
Before:
```
enchantments => null
damage => 2
tool => null
enchantable => {"value":10}
tooltip_display => {}
rarity => "common"
weapon => {"item_damage_per_attack":2}
max_damage => 1561
max_stack_size => 1
repairable => null
lore => []
repair_cost => 0
item_model => "diamond_pickaxe"
break_sound => {"sound_id":"entity.item.break"}
item_name => {"translate":"item.minecraft.diamond_pickaxe"}
attribute_modifiers => [{"type":"attack_damage","id":"base_attack_damage","amount":4.0,"operation":"add_value","slot":"mainhand"},{"type":"attack_speed","id":"base_attack_speed","amount":-2.799999952316284,"operation":"add_value","slot":"mainhand"}]
```

After:
```
enchantments => {"efficiency":1}
damage => 2
tooltip_display => {}
max_stack_size => 1
attribute_modifiers => [{"type":"attack_damage","id":"base_attack_damage","amount":4.0,"operation":"add_value","slot":"mainhand"},{"type":"attack_speed","id":"base_attack_speed","amount":-2.799999952316284,"operation":"add_value","slot":"mainhand"}]
max_damage => 1561
enchantable => {"value":10}
repairable => {"items":"#diamond_tool_materials"}
weapon => {"item_damage_per_attack":2}
repair_cost => 0
tool => {"rules":[{"blocks":"#incorrect_for_diamond_tool","correct_for_drops":false},{"blocks":"#mineable/pickaxe","speed":8.0,"correct_for_drops":true}]}
lore => []
break_sound => "entity.item.break"
rarity => "common"
item_name => {"translate":"item.minecraft.diamond_pickaxe"}
item_model => "diamond_pickaxe"
```