### PR TITLE
Add logout button to alt manager

### DIFF
--- a/src/main/java/net/wurstclient/altmanager/LoginManager.java
+++ b/src/main/java/net/wurstclient/altmanager/LoginManager.java
@@ -23,6 +23,6 @@ public enum LoginManager
 			new Session(newName, Uuids.getOfflinePlayerUuid(newName), "",
 				Optional.empty(), Optional.empty(), Session.AccountType.MOJANG);
 		
-		WurstClient.IMC.setSession(session);
+		WurstClient.IMC.setWurstSession(session);
 	}
 }

--- a/src/main/java/net/wurstclient/altmanager/MicrosoftLoginManager.java
+++ b/src/main/java/net/wurstclient/altmanager/MicrosoftLoginManager.java
@@ -106,7 +106,7 @@ public enum MicrosoftLoginManager
 			mcProfile.getAccessToken(), Optional.empty(), Optional.empty(),
 			Session.AccountType.MSA);
 		
-		WurstClient.IMC.setSession(session);
+		WurstClient.IMC.setWurstSession(session);
 	}
 	
 	private static MinecraftProfile getAccount(String email, String password)

--- a/src/main/java/net/wurstclient/altmanager/screens/AltManagerScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AltManagerScreen.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import net.wurstclient.mixinterface.IMinecraftClient;
 import org.lwjgl.glfw.GLFW;
 
 import com.google.gson.JsonObject;
@@ -151,6 +152,11 @@ public final class AltManagerScreen extends Screen
 		addDrawableChild(exportButton =
 			ButtonWidget.builder(Text.literal("Export"), b -> pressExportAlts())
 				.dimensions(58, 8, 50, 20).build());
+		
+		addDrawableChild(ButtonWidget
+			.builder(Text.literal("Logout"),
+				b -> ((IMinecraftClient)client).setSession(null))
+			.dimensions(width - 50 - 8, 8, 50, 20).build());
 	}
 	
 	@Override

--- a/src/main/java/net/wurstclient/altmanager/screens/AltManagerScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AltManagerScreen.java
@@ -153,10 +153,18 @@ public final class AltManagerScreen extends Screen
 			ButtonWidget.builder(Text.literal("Export"), b -> pressExportAlts())
 				.dimensions(58, 8, 50, 20).build());
 		
-		addDrawableChild(ButtonWidget
-			.builder(Text.literal("Logout"),
-				b -> ((IMinecraftClient)client).setSession(null))
-			.dimensions(width - 50 - 8, 8, 50, 20).build());
+		ButtonWidget logoutButton =
+			addDrawableChild(ButtonWidget.builder(Text.literal("Logout"), b -> {
+				((IMinecraftClient)client).setWurstSession(null);
+				updateLogoutButton(b);
+			}).dimensions(width - 50 - 8, 8, 50, 20).build());
+		updateLogoutButton(logoutButton);
+	}
+	
+	private void updateLogoutButton(ButtonWidget logoutButton)
+	{
+		logoutButton.active =
+			((IMinecraftClient)client).getWurstSession() != null;
 	}
 	
 	@Override

--- a/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
@@ -207,7 +207,13 @@ public abstract class MinecraftClientMixin
 	}
 	
 	@Override
-	public void setSession(Session session)
+	public Session getWurstSession()
+	{
+		return wurstSession;
+	}
+	
+	@Override
+	public void setWurstSession(Session session)
 	{
 		wurstSession = session;
 		if(session == null)

--- a/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
@@ -210,6 +210,11 @@ public abstract class MinecraftClientMixin
 	public void setSession(Session session)
 	{
 		wurstSession = session;
+		if(session == null)
+		{
+			wurstProfileKeys = null;
+			return;
+		}
 		
 		UserApiService userApiService =
 			session.getAccountType() == Session.AccountType.MSA

--- a/src/main/java/net/wurstclient/mixinterface/IMinecraftClient.java
+++ b/src/main/java/net/wurstclient/mixinterface/IMinecraftClient.java
@@ -15,5 +15,7 @@ public interface IMinecraftClient
 	
 	public IClientPlayerEntity getPlayer();
 	
-	public void setSession(Session session);
+	Session getWurstSession();
+	
+	public void setWurstSession(Session session);
 }

--- a/src/main/java/net/wurstclient/mixinterface/IMinecraftClient.java
+++ b/src/main/java/net/wurstclient/mixinterface/IMinecraftClient.java
@@ -15,7 +15,7 @@ public interface IMinecraftClient
 	
 	public IClientPlayerEntity getPlayer();
 	
-	Session getWurstSession();
+	public Session getWurstSession();
 	
 	public void setWurstSession(Session session);
 }


### PR DESCRIPTION
## Description
Allows people to restore their original session in case they don't have it added to the alt manager.

## Testing
Testing has been done by simply logging into an account and then pressing the logout button.

## References
Discord DMs