### PR TITLE
Added "never" option to WurstLogo OTF

### DIFF
--- a/src/main/java/net/wurstclient/other_features/WurstLogoOtf.java
+++ b/src/main/java/net/wurstclient/other_features/WurstLogoOtf.java
@@ -57,7 +57,7 @@ public final class WurstLogoOtf extends OtherFeature
 	public static enum Visibility
 	{
 		ALWAYS("Always", () -> true),
-		
+		NEVER("Never", () -> false),
 		ONLY_OUTDATED("Only when outdated",
 			() -> WURST.getUpdater().isOutdated());
 		


### PR DESCRIPTION
## Description
Added a basic QOL option for users who don't / Can't play on the latest version for a variety of reasons, hiding the logo even if the version is outdated, potentially preventing players getting outed via screenshare too.

## Testing
I tested this on an earlier version of WURST (v7.46.6-MC1.21.4) and there have been zero issues through a brief game session
