### PR TITLE
Fixed NoFog

### DIFF
--- a/src/main/java/net/wurstclient/mixin/BackgroundRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BackgroundRendererMixin.java
@@ -41,7 +41,8 @@ public abstract class BackgroundRendererMixin
 		BackgroundRenderer.FogType fogType, Vector4f color, float viewDistance,
 		boolean thickenFog, float tickDelta)
 	{
-		if(!WurstClient.INSTANCE.getHax().noFogHack.isEnabled() || fogType != BackgroundRenderer.FogType.FOG_TERRAIN)
+		if(!WurstClient.INSTANCE.getHax().noFogHack.isEnabled()
+			|| fogType != BackgroundRenderer.FogType.FOG_TERRAIN)
 			return original.call(start, end, shape, red, green, blue, alpha);
 		
 		CameraSubmersionType cameraSubmersionType = camera.getSubmersionType();

--- a/src/main/java/net/wurstclient/mixin/BackgroundRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BackgroundRendererMixin.java
@@ -41,7 +41,7 @@ public abstract class BackgroundRendererMixin
 		BackgroundRenderer.FogType fogType, Vector4f color, float viewDistance,
 		boolean thickenFog, float tickDelta)
 	{
-		if(!WurstClient.INSTANCE.getHax().noFogHack.isEnabled())
+		if(!WurstClient.INSTANCE.getHax().noFogHack.isEnabled() || fogType != BackgroundRenderer.FogType.FOG_TERRAIN)
 			return original.call(start, end, shape, red, green, blue, alpha);
 		
 		CameraSubmersionType cameraSubmersionType = camera.getSubmersionType();


### PR DESCRIPTION
Fixed NoFog

## Description
> At some point in updating the version of the client, the code for NoFog was changed. Instead of just removing the terrain fog, all fog was removed. This made the sky have a sharp line where it should be blended with fog. I added this back to make the sky look normal.

## Testing
> I've tested this in game to make sure the sky is correct.
