### PR TITLE
Update NewChunksHack.java

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NewChunksHack.java
+++ b/src/main/java/net/wurstclient/hacks/NewChunksHack.java
@@ -158,7 +158,8 @@ public final class NewChunksHack extends Hack
 		if(showSetting.includesNew())
 		{
 			renderer.updateBuffer(0, chunkRenderer.getLayer(),
-				buffer -> chunkRenderer.buildBuffer(buffer, newChunks, dd));
+			// FIX: Copy the set to avoid ConcurrentModificationException
+            			buffer -> chunkRenderer.buildBuffer(buffer, List.copyOf(newChunks), dd));
 			
 			if(showReasons.isChecked())
 				renderer.updateBuffer(1, reasonsRenderer.getLayer(),
@@ -169,7 +170,8 @@ public final class NewChunksHack extends Hack
 		if(showSetting.includesOld())
 		{
 			renderer.updateBuffer(2, chunkRenderer.getLayer(),
-				buffer -> chunkRenderer.buildBuffer(buffer, oldChunks, dd));
+			// FIX: Copy the set to avoid ConcurrentModificationException
+            			buffer -> chunkRenderer.buildBuffer(buffer, List.copyOf(oldChunks), dd));
 			
 			if(showReasons.isChecked())
 				renderer.updateBuffer(3, reasonsRenderer.getLayer(),


### PR DESCRIPTION
## Description
Fix ConcurrentModificationException in NewChunksHack by iterating over copies of newChunks and oldChunks during buffer update. This prevents crashes when these sets are modified from other threads.

Description: Firing Wurst event

java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605)
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1628)
	at knot//net.wurstclient.hacks.newchunks.NewChunksOutlineRenderer.buildBuffer(NewChunksOutlineRenderer.java:29)
	at knot//net.wurstclient.hacks.NewChunksHack.lambda$onUpdate$2(NewChunksHack.java:172)
	at knot//net.wurstclient.util.EasyVertexBuffer.createAndUpload(EasyVertexBuffer.java:45)
	at knot//net.wurstclient.util.BufferWithLayer.createAndUpload(BufferWithLayer.java:22)
	at knot//net.wurstclient.hacks.newchunks.NewChunksRenderer.updateBuffer(NewChunksRenderer.java:43)
	at knot//net.wurstclient.hacks.NewChunksHack.onUpdate(NewChunksHack.java:171)
	at knot//net.wurstclient.events.UpdateListener$UpdateEvent.fire(UpdateListener.java:27)
	at knot//net.wurstclient.event.EventManager.fireImpl(EventManager.java:69)
	at knot//net.wurstclient.event.EventManager.fire(EventManager.java:42)
	at knot//net.minecraft.class_746.handler$blh001$wurst$onTick(class_746.java:1880)
	at knot//net.minecraft.class_746.method_5773(class_746.java:221)
	at knot//net.minecraft.class_1297.method_5842(class_1297.java:2154)
	at knot//net.minecraft.class_1309.method_5842(class_1309.java:2971)
	at knot//net.minecraft.class_1657.method_5842(class_1657.java:560)
	at knot//net.minecraft.class_746.method_5842(class_746.java:901)
	at knot//net.minecraft.class_638.method_18647(class_638.java:299)
	at knot//net.minecraft.class_638.method_18646(class_638.java:282)
	at knot//net.minecraft.class_1937.method_18472(class_1937.java:498)
	at knot//net.minecraft.class_638.method_32124(class_638.java:261)
	at knot//net.minecraft.class_5574.method_31791(class_5574.java:54)
	at knot//net.minecraft.class_638.method_18116(class_638.java:257)
	at knot//net.minecraft.class_310.method_1574(class_310.java:1956)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1246)
	at knot//net.minecraft.class_310.method_1514(class_310.java:882)
	at knot//net.minecraft.client.main.Main.main(Main.java:256)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
