### PR TITLE
Fix FakePlayerEntity pushing away the player

### DIFF
--- a/src/main/java/net/wurstclient/util/FakePlayerEntity.java
+++ b/src/main/java/net/wurstclient/util/FakePlayerEntity.java
@@ -51,6 +51,12 @@ public class FakePlayerEntity extends OtherClientPlayerEntity
 		return playerListEntry;
 	}
 	
+	@Override
+	protected void pushAway(Entity entity)
+	{
+		// Prevents pushing the real player away
+	}
+	
 	private void copyInventory()
 	{
 		getInventory().clone(player.getInventory());


### PR DESCRIPTION
## Description
When using Blink hack, player would get pushed away on collision with the fake player.

## Testing
Before:

https://github.com/user-attachments/assets/7d30dbe4-2261-4eef-ac52-d2d96732124d

After:

https://github.com/user-attachments/assets/f9cc592b-62ff-4ef5-9c51-b7b7200ee02c


