### PR TITLE
Bump Gradle Version 8.12.1 -> 8.14.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
> Bumped the gradle version from 8.12.1 to the latest (8.14.2). I'm not sure if this is just a me issue, but my command prompt commands don't work on the old version. It's alright if this doesn't get merged, I just want to make sure I don't keep accidentally pushing this change.

## Testing
> I've confirmed that I can clean, splotlessApply, and build just fine. 