### PR TITLE
Fix Radar player arrow rotation

### DIFF
--- a/src/main/java/net/wurstclient/clickgui/components/RadarComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/RadarComponent.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.passive.WaterAnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.wurstclient.clickgui.ClickGui;
 import net.wurstclient.clickgui.ClickGuiIcons;
@@ -65,9 +66,11 @@ public final class RadarComponent extends Component
 		matrixStack.translate(middleX, middleY);
 		
 		ClientPlayerEntity player = MC.player;
-		// if(!hack.isRotateEnabled()) FIXME
-		// matrixStack.multiply(new Quaternionf().rotationZ(
-		// (180 + player.getYaw()) * MathHelper.RADIANS_PER_DEGREE));
+		if(!hack.isRotateEnabled())
+		{
+			matrixStack.rotate(
+				(180 + player.getYaw()) * MathHelper.RADIANS_PER_DEGREE);
+		}
 		
 		// arrow
 		ClickGuiIcons.drawRadarArrow(context, -2, -2, 2, 2);


### PR DESCRIPTION
## Description
Fixed the rotation of the player arrow (visible when `Rotate with player` is disabled).
It now works the same way it did prior to 1.21.6 update.