### PR TITLE
Xray hack changes - Refresh world upon setting change

### DIFF
--- a/src/main/java/net/wurstclient/clickgui/components/SliderComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/SliderComponent.java
@@ -186,6 +186,11 @@ public final class SliderComponent extends Component
 		return tooltip;
 	}
 	
+	public boolean isDragging()
+	{
+		return this.dragging;
+	}
+	
 	@Override
 	public int getDefaultWidth()
 	{

--- a/src/main/java/net/wurstclient/hacks/XRayHack.java
+++ b/src/main/java/net/wurstclient/hacks/XRayHack.java
@@ -42,6 +42,27 @@ public final class XRayHack extends Hack implements UpdateListener,
 	SetOpaqueCubeListener, GetAmbientOcclusionLightLevelListener,
 	ShouldDrawSideListener, RenderBlockEntityListener
 {
+	private final CheckboxSetting refreshable = new CheckboxSetting(
+		"Refresh renders live",
+		"Refresh renders while the module is enabled. Disable this if lagging while"
+			+ " updating opacity.\n\n"
+			+ "Don't forget to toggle the module after changes if this is disabled!",
+		true)
+	{
+		@Override
+		public void update()
+		{
+			XRayHack xRayHack = WurstClient.INSTANCE.getHax().xRayHack;
+			
+			if(xRayHack == null || !xRayHack.isEnabled()
+				|| !xRayHack.refreshable.isChecked())
+				return;
+			
+			refreshOreNamesCache();
+			refreshXray();
+		}
+	};
+	
 	private final BlockListSetting ores = new BlockListSetting("Ores",
 		"A list of blocks that X-Ray will show. They don't have to be just ores"
 			+ " - you can add any block you want.",
@@ -80,8 +101,10 @@ public final class XRayHack extends Hack implements UpdateListener,
 		@Override
 		public void update()
 		{
+			XRayHack xRayHack = WurstClient.INSTANCE.getHax().xRayHack;
 			
-			if(!WurstClient.INSTANCE.getHax().xRayHack.isEnabled())
+			if(xRayHack == null || !xRayHack.isEnabled()
+				|| !xRayHack.refreshable.isChecked())
 				return;
 			
 			refreshOreNamesCache();
@@ -98,8 +121,10 @@ public final class XRayHack extends Hack implements UpdateListener,
 		@Override
 		public void update()
 		{
+			XRayHack xRayHack = WurstClient.INSTANCE.getHax().xRayHack;
 			
-			if(!WurstClient.INSTANCE.getHax().xRayHack.isEnabled())
+			if(xRayHack == null || !xRayHack.isEnabled()
+				|| !xRayHack.refreshable.isChecked())
 				return;
 			
 			refreshXray();
@@ -114,8 +139,10 @@ public final class XRayHack extends Hack implements UpdateListener,
 		@Override
 		public void update()
 		{
+			XRayHack xRayHack = WurstClient.INSTANCE.getHax().xRayHack;
 			
-			if(!WurstClient.INSTANCE.getHax().xRayHack.isEnabled())
+			if(xRayHack == null || !xRayHack.isEnabled()
+				|| !xRayHack.refreshable.isChecked())
 				return;
 			
 			refreshXray();
@@ -134,6 +161,7 @@ public final class XRayHack extends Hack implements UpdateListener,
 	{
 		super("X-Ray");
 		setCategory(Category.RENDER);
+		addSetting(refreshable);
 		addSetting(ores);
 		addSetting(onlyExposed);
 		addSetting(opacity);

--- a/src/main/java/net/wurstclient/hacks/XRayHack.java
+++ b/src/main/java/net/wurstclient/hacks/XRayHack.java
@@ -47,7 +47,7 @@ public final class XRayHack extends Hack implements UpdateListener,
 		"Refresh renders while the module is enabled. Disable this if lagging while"
 			+ " updating opacity.\n\n"
 			+ "Don't forget to toggle the module after changes if this is disabled!",
-		true)
+		false)
 	{
 		@Override
 		public void update()

--- a/src/main/java/net/wurstclient/hacks/XRayHack.java
+++ b/src/main/java/net/wurstclient/hacks/XRayHack.java
@@ -131,7 +131,7 @@ public final class XRayHack extends Hack implements UpdateListener,
 			SliderComponent sliderComponent =
 				(SliderComponent)this.getComponent();
 			
-			if(triggeredOpacityRefresh || sliderComponent.isDragging())
+			if(sliderComponent.isDragging())
 			{
 				triggeredOpacityRefresh = true;
 				return;

--- a/src/main/java/net/wurstclient/settings/BlockListSetting.java
+++ b/src/main/java/net/wurstclient/settings/BlockListSetting.java
@@ -95,6 +95,7 @@ public class BlockListSetting extends Setting
 		
 		blockNames.add(name);
 		Collections.sort(blockNames);
+		update();
 		WurstClient.INSTANCE.saveSettings();
 	}
 	
@@ -104,6 +105,7 @@ public class BlockListSetting extends Setting
 			return;
 		
 		blockNames.remove(index);
+		update();
 		WurstClient.INSTANCE.saveSettings();
 	}
 	
@@ -111,6 +113,7 @@ public class BlockListSetting extends Setting
 	{
 		blockNames.clear();
 		blockNames.addAll(Arrays.asList(defaultNames));
+		update();
 		WurstClient.INSTANCE.saveSettings();
 	}
 	

--- a/src/main/java/net/wurstclient/settings/SliderSetting.java
+++ b/src/main/java/net/wurstclient/settings/SliderSetting.java
@@ -31,6 +31,7 @@ public class SliderSetting extends Setting implements SliderLock
 	private final double maximum;
 	private final double increment;
 	private final ValueDisplay display;
+	private SliderComponent sliderComponent = null;
 	
 	private SliderLock lock;
 	private boolean disabled;
@@ -253,7 +254,12 @@ public class SliderSetting extends Setting implements SliderLock
 	@Override
 	public final Component getComponent()
 	{
-		return new SliderComponent(this);
+		if(this.sliderComponent == null)
+		{
+			this.sliderComponent = new SliderComponent(this);
+		}
+		
+		return this.sliderComponent;
 	}
 	
 	@Override


### PR DESCRIPTION
## Description
> This PR adds a live refresh to setting modifications when Xray is enabled, thus no longer requiring the module to be toggled to see settings applied.

> What triggers a refresh:
> - Changes to the block list.
> - If the show exposed setting is toggled.
> - Slider opacity... This setting is a bit more complicated to refresh due to how Wurst changes the values when sliding the setting bar. The method to update opacity now checks to see if the slider is dragging. If dragging, there are no world refreshes. Once the setting is no longer dragging, the world refreshes if the value was changed. This prevents the world from refreshing hundreds of times while changing the slider.

## Testing
> I've tested this in game and ensured that the client builds. I know opacity doesn't work with sodium, but I have not tested this with it.  See the attached video demonstration.

https://youtu.be/NcXBuAHXrDE