### PR TITLE
Fix KillPotion and TrollPotion hacks

### DIFF
--- a/src/main/java/net/wurstclient/hacks/KillPotionHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillPotionHack.java
@@ -71,6 +71,7 @@ public final class KillPotionHack extends Hack
 			if(!MC.player.getInventory().getStack(i).isEmpty())
 				continue;
 			
+			MC.player.getInventory().setStack(i, stack);
 			MC.player.networkHandler.sendPacket(
 				new CreativeInventoryActionC2SPacket(36 + i, stack));
 			return true;

--- a/src/main/java/net/wurstclient/hacks/TrollPotionHack.java
+++ b/src/main/java/net/wurstclient/hacks/TrollPotionHack.java
@@ -71,6 +71,7 @@ public final class TrollPotionHack extends Hack
 			if(!MC.player.getInventory().getStack(i).isEmpty())
 				continue;
 			
+			MC.player.getInventory().setStack(i, stack);
 			MC.player.networkHandler.sendPacket(
 				new CreativeInventoryActionC2SPacket(36 + i, stack));
 			return true;


### PR DESCRIPTION
## Description
These hacks appear to have been broken since Minecraft 1.21.2.
Hacks would send a packet to the server, but the player's inventory was not updated properly. As a result, the generated potion would not appear in the inventory until the player reconnected to the server.

## References
https://wurstforum.net/d/1209-reporting-a-bug
