### PR TITLE
Prevent ConcurrentModificationException in NewChunksHack. Fixes #1190

### DIFF
--- a/src/main/java/net/wurstclient/hacks/NewChunksHack.java
+++ b/src/main/java/net/wurstclient/hacks/NewChunksHack.java
@@ -8,10 +8,9 @@
 package net.wurstclient.hacks;
 
 import java.awt.Color;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.fluid.FluidState;
@@ -72,17 +71,12 @@ public final class NewChunksHack extends Hack
 	private final CheckboxSetting logChunks = new CheckboxSetting("Log chunks",
 		"Writes to the log file when a new/old chunk is found.", false);
 	
-	private final Set<ChunkPos> newChunks =
-		Collections.synchronizedSet(new HashSet<>());
-	private final Set<ChunkPos> oldChunks =
-		Collections.synchronizedSet(new HashSet<>());
-	private final Set<ChunkPos> dontCheckAgain =
-		Collections.synchronizedSet(new HashSet<>());
+	private final Set<ChunkPos> newChunks = ConcurrentHashMap.newKeySet();
+	private final Set<ChunkPos> oldChunks = ConcurrentHashMap.newKeySet();
+	private final Set<ChunkPos> dontCheckAgain = ConcurrentHashMap.newKeySet();
 	
-	private final Set<BlockPos> newChunkReasons =
-		Collections.synchronizedSet(new HashSet<>());
-	private final Set<BlockPos> oldChunkReasons =
-		Collections.synchronizedSet(new HashSet<>());
+	private final Set<BlockPos> newChunkReasons = ConcurrentHashMap.newKeySet();
+	private final Set<BlockPos> oldChunkReasons = ConcurrentHashMap.newKeySet();
 	
 	private final NewChunksRenderer renderer = new NewChunksRenderer(altitude,
 		opacity, newChunksColor, oldChunksColor);


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
Race conditions happen and lead to ConcurrentModificationExceptions in NewChunks renderers probably because of multithreading. This pull request fixes this issue by migrating to `ConcurrentHashMap.newKeySet` instead of using `Collections.synchronizedSet(new HashSet<>())` (which doesn't ensure thread-safety while iterating)

## Testing
I also had the same issue and this patch got rid of it.

## References
The same issue can be seen here: #1190