### PR TITLE
1.20.1 AntiWaterPush->Prevent slowdown abnormal twitching fix

### DIFF
--- a/src/main/java/net/wurstclient/events/GetPlayerDepthStriderListener.java
+++ b/src/main/java/net/wurstclient/events/GetPlayerDepthStriderListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.events;
+
+import net.minecraft.entity.Entity;
+import net.wurstclient.event.CancellableEvent;
+import net.wurstclient.event.Listener;
+
+import java.util.ArrayList;
+
+public interface GetPlayerDepthStriderListener extends Listener
+{
+	public void onGetPlayerDepthStrider(GetPlayerDepthStriderEvent event);
+	
+	public static class GetPlayerDepthStriderEvent
+		extends CancellableEvent<GetPlayerDepthStriderListener>
+	{
+		private final Entity entity;
+		
+		public GetPlayerDepthStriderEvent(Entity entity)
+		{
+			this.entity = entity;
+		}
+		
+		public Entity getEntity()
+		{
+			return entity;
+		}
+		
+		@Override
+		public void fire(ArrayList<GetPlayerDepthStriderListener> listeners)
+		{
+			for(GetPlayerDepthStriderListener listener : listeners)
+			{
+				listener.onGetPlayerDepthStrider(this);
+				if(isCancelled())
+					break;
+			}
+		}
+		
+		@Override
+		public Class<GetPlayerDepthStriderListener> getListenerType()
+		{
+			return GetPlayerDepthStriderListener.class;
+		}
+	}
+}

--- a/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
@@ -10,7 +10,6 @@ package net.wurstclient.hacks;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.events.GetPlayerDepthStriderListener;
-import net.wurstclient.events.IsPlayerInWaterListener;
 import net.wurstclient.events.UpdateListener;
 import net.wurstclient.events.VelocityFromFluidListener;
 import net.wurstclient.hack.Hack;
@@ -67,18 +66,19 @@ public final class AntiWaterPushHack extends Hack implements UpdateListener,
 	}
 	
 	@Override
-	public void onVelocityFromFluid(VelocityFromFluidListener.VelocityFromFluidEvent event)
+	public void onVelocityFromFluid(
+		VelocityFromFluidListener.VelocityFromFluidEvent event)
 	{
 		if(event.getEntity() == MC.player)
 			event.cancel();
 	}
-
+	
 	@Override
 	public void onGetPlayerDepthStrider(GetPlayerDepthStriderEvent event)
 	{
-		if (isPreventingSlowdown() && event.getEntity() == MC.player)
+		if(isPreventingSlowdown() && event.getEntity() == MC.player)
 			event.cancel();
-
+		
 	}
 	
 	public boolean isPreventingSlowdown()

--- a/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
@@ -9,6 +9,7 @@ package net.wurstclient.hacks;
 
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
+import net.wurstclient.events.GetPlayerDepthStriderListener;
 import net.wurstclient.events.IsPlayerInWaterListener;
 import net.wurstclient.events.UpdateListener;
 import net.wurstclient.events.VelocityFromFluidListener;
@@ -17,7 +18,7 @@ import net.wurstclient.settings.CheckboxSetting;
 
 @SearchTags({"anti water push", "NoWaterPush", "no water push"})
 public final class AntiWaterPushHack extends Hack implements UpdateListener,
-	VelocityFromFluidListener, IsPlayerInWaterListener
+	VelocityFromFluidListener, GetPlayerDepthStriderListener
 {
 	private final CheckboxSetting preventSlowdown = new CheckboxSetting(
 		"Prevent slowdown", "Allows you to walk underwater at full speed.\n"
@@ -36,7 +37,7 @@ public final class AntiWaterPushHack extends Hack implements UpdateListener,
 	{
 		EVENTS.add(UpdateListener.class, this);
 		EVENTS.add(VelocityFromFluidListener.class, this);
-		EVENTS.add(IsPlayerInWaterListener.class, this);
+		EVENTS.add(GetPlayerDepthStriderListener.class, this);
 	}
 	
 	@Override
@@ -44,7 +45,7 @@ public final class AntiWaterPushHack extends Hack implements UpdateListener,
 	{
 		EVENTS.remove(UpdateListener.class, this);
 		EVENTS.remove(VelocityFromFluidListener.class, this);
-		EVENTS.remove(IsPlayerInWaterListener.class, this);
+		EVENTS.remove(GetPlayerDepthStriderListener.class, this);
 	}
 	
 	@Override
@@ -66,21 +67,23 @@ public final class AntiWaterPushHack extends Hack implements UpdateListener,
 	}
 	
 	@Override
-	public void onVelocityFromFluid(VelocityFromFluidEvent event)
+	public void onVelocityFromFluid(VelocityFromFluidListener.VelocityFromFluidEvent event)
 	{
 		if(event.getEntity() == MC.player)
 			event.cancel();
 	}
-	
+
 	@Override
-	public void onIsPlayerInWater(IsPlayerInWaterEvent event)
+	public void onGetPlayerDepthStrider(GetPlayerDepthStriderEvent event)
 	{
-		if(preventSlowdown.isChecked())
-			event.setInWater(false);
+		if (isPreventingSlowdown() && event.getEntity() == MC.player)
+			event.cancel();
+
 	}
 	
 	public boolean isPreventingSlowdown()
 	{
 		return preventSlowdown.isChecked();
 	}
+	
 }

--- a/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
@@ -1,0 +1,20 @@
+package net.wurstclient.mixin;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.LivingEntity;
+import net.wurstclient.event.EventManager;
+import net.wurstclient.events.GetPlayerDepthStriderListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(LivingEntity.class)
+public class LivingEntityMixin
+{
+    @Redirect(method = "travel", at = @At(value = "INVOKE", target = "Lnet/minecraft/enchantment/EnchantmentHelper;getDepthStrider(Lnet/minecraft/entity/LivingEntity;)I"))
+    private int getDepthStrider(LivingEntity entity){
+        GetPlayerDepthStriderListener.GetPlayerDepthStriderEvent event = new GetPlayerDepthStriderListener.GetPlayerDepthStriderEvent(entity);
+        EventManager.fire(event);
+        return event.isCancelled()?3: EnchantmentHelper.getDepthStrider(entity);
+    }
+}

--- a/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
 package net.wurstclient.mixin;
 
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -11,10 +18,16 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin
 {
-    @Redirect(method = "travel", at = @At(value = "INVOKE", target = "Lnet/minecraft/enchantment/EnchantmentHelper;getDepthStrider(Lnet/minecraft/entity/LivingEntity;)I"))
-    private int getDepthStrider(LivingEntity entity){
-        GetPlayerDepthStriderListener.GetPlayerDepthStriderEvent event = new GetPlayerDepthStriderListener.GetPlayerDepthStriderEvent(entity);
-        EventManager.fire(event);
-        return event.isCancelled()?3: EnchantmentHelper.getDepthStrider(entity);
-    }
+	@Redirect(method = "travel",
+		at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/enchantment/EnchantmentHelper;getDepthStrider(Lnet/minecraft/entity/LivingEntity;)I"))
+	private int getDepthStrider(LivingEntity entity)
+	{
+		GetPlayerDepthStriderListener.GetPlayerDepthStriderEvent event =
+			new GetPlayerDepthStriderListener.GetPlayerDepthStriderEvent(
+				entity);
+		EventManager.fire(event);
+		return event.isCancelled() ? 3
+			: EnchantmentHelper.getDepthStrider(entity);
+	}
 }

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -44,6 +44,7 @@
     "LanguageManagerMixin",
     "LightmapTextureManagerMixin",
     "LivingEntityRendererMixin",
+    "LivingEntityMixin",
     "MinecraftClientMixin",
     "MobEntityRendererMixin",
     "MouseMixin",


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
> What have you added and what does it do? (Alternatively, what have you fixed and how does it work?)
Previously, enabling Prevent solwdown would cause abnormal twitching when sprinting in the pool, changed the implementation of Prevent solwdown in AntiWaterPush, using the travel method injected into LivingEntity to obtain the player's DepthStrider level if enabled Return 3 otherwise return on demand

## Testing
> How have you tested your changes? Any testing tips for the reviewer?
1.Create a world/enter a server
2.Create 3 6*6 pools The first one is poured into the corner The second layer is full of water The third layer (3 storeys high) lay some blocks on the edges Then the rest of the 1-2 layers of water Put some water on the edge squares
3.Finally, turn on AntiWaterPush to test whether the water has a push in the first/third pool, then turn on Prevent slowdown, test whether you can move around quickly, and then try sprints (swimming positions), jumps, etc. in the third pool


## References
> List any related issues, forum posts, videos and such here.
Vedio: Please Download
[https://github.com/Rczlin/My/blob/main/UploadWrustPRTestVedio.7z](url)