### PR TITLE
Fix X-Ray fluid rendering with Sodium

### DIFF
--- a/src/gametest/java/net/wurstclient/gametest/tests/XRayHackTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/XRayHackTest.java
@@ -38,8 +38,7 @@ public enum XRayHackTest
 		input.pressKey(GLFW.GLFW_KEY_X);
 		waitForChunkReloading(context, world);
 		assertScreenshotEquals(context, "xray_default",
-			WurstTest.IS_MOD_COMPAT_TEST ? "https://i.imgur.com/erO3kia.png"
-				: "https://i.imgur.com/Dftamqv.png");
+			"https://i.imgur.com/Dftamqv.png");
 		
 		// Exposed only
 		runWurstCommand(context, "setcheckbox X-Ray only_show_exposed on");
@@ -48,8 +47,7 @@ public enum XRayHackTest
 		input.pressKey(GLFW.GLFW_KEY_X);
 		waitForChunkReloading(context, world);
 		assertScreenshotEquals(context, "xray_exposed_only",
-			WurstTest.IS_MOD_COMPAT_TEST ? "https://i.imgur.com/yjCT7jI.png"
-				: "https://i.imgur.com/QlEpQTu.png");
+			"https://i.imgur.com/QlEpQTu.png");
 		
 		// Opacity mode
 		runWurstCommand(context, "setcheckbox X-Ray only_show_exposed off");
@@ -58,8 +56,7 @@ public enum XRayHackTest
 		input.pressKey(GLFW.GLFW_KEY_X);
 		waitForChunkReloading(context, world);
 		assertScreenshotEquals(context, "xray_opacity",
-			WurstTest.IS_MOD_COMPAT_TEST ? "https://i.imgur.com/LKaCXNd.png"
-				: "https://i.imgur.com/0nLulJn.png");
+			"https://i.imgur.com/0nLulJn.png");
 		
 		// Exposed only + opacity
 		runWurstCommand(context, "setcheckbox X-Ray only_show_exposed on");
@@ -68,8 +65,7 @@ public enum XRayHackTest
 		input.pressKey(GLFW.GLFW_KEY_X);
 		waitForChunkReloading(context, world);
 		assertScreenshotEquals(context, "xray_exposed_only_opacity",
-			WurstTest.IS_MOD_COMPAT_TEST ? "https://i.imgur.com/0OmJCsi.png"
-				: "https://i.imgur.com/noPWDUl.png");
+			"https://i.imgur.com/noPWDUl.png");
 		
 		// Clean up
 		runCommand(server, "fill ~-5 ~-2 ~5 ~5 ~5 ~7 air");

--- a/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
@@ -46,6 +46,7 @@ public class FluidRendererMixin
 		BlockAndTintGetter world, BlockPos pos, VertexConsumer vertexConsumer,
 		BlockState blockState, FluidState fluidState)
 	{
+		// Note: the null BlockPos is here to skip the "exposed only" check
 		ShouldDrawSideEvent event = new ShouldDrawSideEvent(blockState, null);
 		EventManager.fire(event);
 		

--- a/src/main/java/net/wurstclient/mixin/sodium/DefaultFluidRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/sodium/DefaultFluidRendererMixin.java
@@ -49,7 +49,8 @@ public class DefaultFluidRendererMixin
 		BlockPos pos, Direction dir, BlockState state, FluidState fluid,
 		CallbackInfoReturnable<Boolean> cir)
 	{
-		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, pos);
+		// Note: the null BlockPos is here to skip the "exposed only" check
+		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, null);
 		EventManager.fire(event);
 		
 		if(event.isRendered() != null)
@@ -71,7 +72,8 @@ public class DefaultFluidRendererMixin
 		BlockPos pos = new BlockPos(x, y, z);
 		BlockState state = world.getBlockState(pos);
 		
-		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, pos);
+		// Note: the null BlockPos is here to skip the "exposed only" check
+		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, null);
 		EventManager.fire(event);
 		
 		if(event.isRendered() == null)


### PR DESCRIPTION
## Description
When using Sodium, fluids were not rendered correctly. This prevented players from seeing anything while submerged with X-ray enabled.
The new implementation should now be on par with Indigo.

## Testing
Tested manually. ~~Couldn't update Sodium screenshot templates in the automated tests, since screenshots produced by `clientGameTest` on my PCs always slightly differ from those in CI (seems like some sort of window scaling issue on my end).~~

Edit: I decided to see if it would work through X instead of Wayland. It sure did.
_"Wayland breaks everything"_ lives on.

## References

X-Ray off
<img width="2560" height="1440" alt="off" src="https://github.com/user-attachments/assets/3e5ca1ec-87ee-4a0d-bae7-a80ce45af8e5" />

Indigo
<img width="2560" height="1440" alt="indigo" src="https://github.com/user-attachments/assets/0844bb2c-9c28-4870-9353-c022674d5797" />

Sodium (pre fix)
<img width="2560" height="1440" alt="err" src="https://github.com/user-attachments/assets/9582bfaa-274b-470a-9a7a-0557b3690978" />

Sodium (post fix)
<img width="2560" height="1440" alt="fixed" src="https://github.com/user-attachments/assets/326087f3-2078-4e78-9499-facd2fe5c406" />

