### PR TITLE
Fix moved wrongly error when using both noFall and fligiht hacks.

### DIFF
--- a/src/main/java/net/wurstclient/hacks/FlightHack.java
+++ b/src/main/java/net/wurstclient/hacks/FlightHack.java
@@ -104,8 +104,7 @@ public final class FlightHack extends Hack
 		
 		if(MC.options.keyShift.isDown())
 		{
-			// Avoid sneaking to disable server-side Player.backOffFromEdge
-			// check.
+			// Cancel sneaking to disable server backOffFromEdge check.
 			// This bypasses Moved Wrongly error when enabling noFall.
 			if(WURST.getHax().noFallHack.isEnabled())
 			{
@@ -159,4 +158,3 @@ public final class FlightHack extends Hack
 		event.setInWater(false);
 	}
 }
-


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
Fix moved wrongly error when using both noFall and flight hacks.

When the server handles player's movement packet, it tries to simulate the movement on the server side, and rejects if there's any significant discrepancy.

```java
// simulate the move on the server side.
this.player.move(MoverType.PLAYER, new Vec3(deltaX, deltaY, deltaZ));
deltaX = targetX - this.player.getX();
deltaY = targetY - this.player.getY();
if (deltaY > -0.5 || deltaY < 0.5) {
    deltaY = 0.0;
}
deltaZ = targetZ - this.player.getZ();
distanceSqr = deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;

// compare the difference between client destination and the server simulated destination.
boolean isMovementInvalid = false;
if (!this.player.isChangingDimension() && distanceSqr > 0.0625 && !this.player.isSleeping() && !this.player.isCreative() && !this.player.isSpectator()) {
isMovementInvalid = true;
LOGGER.warn("{} moved wrongly!", this.player.getPlainTextName());
}
```

Which in turns calls Entity.move() and checks if the player can fall off the edges.
```java
movement = this.maybeBackOffFromEdge(movement, moverType);


// In Player.java
@Override
    protected Vec3 maybeBackOffFromEdge(Vec3 movement, MoverType moverType) {
        // The "SafeWalk" Check Conditions:
        // 1. Not flying
        // 2. Not moving Up (Jumping overrides SafeWalk)
        // 3. Moving by self (not being pushed by piston)
        // 4. "isStayingOnGroundSurface" -> This returns true if (Sneaking AND OnGround)
        // 5. "isAboveGround" -> Ensures we are actually currently on a block
        if (!this.abilities.flying
                && !(movement.y > 0.0)
                && (moverType == MoverType.SELF || moverType == MoverType.PLAYER)
                && this.isStayingOnGroundSurface()
                && this.isAboveGround(maxUpStep)) {
   // blah blah blah
}
```

When both the flight and noFall are on, and the player presses SHIFT to descend, the server perceives player is both sneaking and on the ground. Therefore it will trigger the maybeBackOffFromEdge and results in significant destination discrepancy that causes MOVED WRONGLY warning in the console. Therefore, if no fall is on, flight should disable crouching before sending the packet. This however, does not affect

## Testing
Start a random minecraft server, and disables allowFly.
Enable both noFall and flight hack. Hover in midair, and press shift to descend.
Observe there's no player moved wrongly warning.

## References
> List any related issues, forum posts, videos and such here.
