### PR TITLE
Fix anti kick feature in the FlightHack.

### DIFF
--- a/src/main/java/net/wurstclient/hacks/FlightHack.java
+++ b/src/main/java/net/wurstclient/hacks/FlightHack.java
@@ -174,7 +174,7 @@ public final class FlightHack extends Hack implements UpdateListener,
 		{
 			case 0 ->
 			{
-				if(IKeyMapping.get(MC.options.keyShift).isActuallyDown())
+				if(velocity.y <= -antiKickDistance.getValue())
 					tickCounter = 2;
 				else
 					MC.player.setDeltaMovement(velocity.x,


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
In the commit https://github.com/Wurst-Imperium/Wurst7/commit/8084f2804a11c74673a1f27117a3611bf6653493#diff-a381f00f04a22306c121ecb8bc84d0a6c7714cf00ba4e571beffb9e082f20cd3R128-R178

We should use setDeltaMovement() instead of addDeltaMovement(), otherwies if the player holds spacebar to go up, the y velocity from the flight hack will be greater than the anti-kcik's downward y velocity, and result in net positive y velocity, and the player will get kicked.

Looks like it was a typo that sneaked in during the refactory.

## Testing
Join a vanilla server with allowFly = false.
Turn on anti-kick, and flight upward by continuing holding the space button.
Notice the player is not kicked from the server.

## References
> List any related issues, forum posts, videos and such here.
