### PR TITLE
Run spotlessApply to fix copyright statement in 1.21.8

### DIFF
--- a/src/gametest/java/net/wurstclient/gametest/WurstClientTestHelper.java
+++ b/src/gametest/java/net/wurstclient/gametest/WurstClientTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/WurstTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/WurstTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/mixin/ScreenMixin.java
+++ b/src/gametest/java/net/wurstclient/gametest/mixin/ScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/AltManagerTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/AltManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/AutoMineHackTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/AutoMineHackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/CopyItemCmdTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/CopyItemCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/FreecamHackTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/FreecamHackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/GiveCmdTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/GiveCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/ModifyCmdTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/ModifyCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/NoFallHackTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/NoFallHackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/PistonTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/PistonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/gametest/java/net/wurstclient/gametest/tests/XRayHackTest.java
+++ b/src/gametest/java/net/wurstclient/gametest/tests/XRayHackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/Category.java
+++ b/src/main/java/net/wurstclient/Category.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/DontBlock.java
+++ b/src/main/java/net/wurstclient/DontBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/Feature.java
+++ b/src/main/java/net/wurstclient/Feature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/FriendsList.java
+++ b/src/main/java/net/wurstclient/FriendsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/RotationFaker.java
+++ b/src/main/java/net/wurstclient/RotationFaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/SearchTags.java
+++ b/src/main/java/net/wurstclient/SearchTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/TooManyHaxFile.java
+++ b/src/main/java/net/wurstclient/TooManyHaxFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/WurstClient.java
+++ b/src/main/java/net/wurstclient/WurstClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/WurstInitializer.java
+++ b/src/main/java/net/wurstclient/WurstInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/WurstRenderLayers.java
+++ b/src/main/java/net/wurstclient/WurstRenderLayers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/WurstShaderPipelines.java
+++ b/src/main/java/net/wurstclient/WurstShaderPipelines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/WurstTranslator.java
+++ b/src/main/java/net/wurstclient/WurstTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/FlyPathProcessor.java
+++ b/src/main/java/net/wurstclient/ai/FlyPathProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/PathFinder.java
+++ b/src/main/java/net/wurstclient/ai/PathFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/PathPos.java
+++ b/src/main/java/net/wurstclient/ai/PathPos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/PathProcessor.java
+++ b/src/main/java/net/wurstclient/ai/PathProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/PathQueue.java
+++ b/src/main/java/net/wurstclient/ai/PathQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/PlayerAbilities.java
+++ b/src/main/java/net/wurstclient/ai/PlayerAbilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/ai/WalkPathProcessor.java
+++ b/src/main/java/net/wurstclient/ai/WalkPathProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/Alt.java
+++ b/src/main/java/net/wurstclient/altmanager/Alt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/AltManager.java
+++ b/src/main/java/net/wurstclient/altmanager/AltManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/AltRenderer.java
+++ b/src/main/java/net/wurstclient/altmanager/AltRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/AltsFile.java
+++ b/src/main/java/net/wurstclient/altmanager/AltsFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/CrackedAlt.java
+++ b/src/main/java/net/wurstclient/altmanager/CrackedAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/Encryption.java
+++ b/src/main/java/net/wurstclient/altmanager/Encryption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/ExportAltsFileChooser.java
+++ b/src/main/java/net/wurstclient/altmanager/ExportAltsFileChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/ImportAltsFileChooser.java
+++ b/src/main/java/net/wurstclient/altmanager/ImportAltsFileChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/LoginException.java
+++ b/src/main/java/net/wurstclient/altmanager/LoginException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/LoginManager.java
+++ b/src/main/java/net/wurstclient/altmanager/LoginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/MicrosoftLoginManager.java
+++ b/src/main/java/net/wurstclient/altmanager/MicrosoftLoginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/MinecraftProfile.java
+++ b/src/main/java/net/wurstclient/altmanager/MinecraftProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/MojangAlt.java
+++ b/src/main/java/net/wurstclient/altmanager/MojangAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/NameGenerator.java
+++ b/src/main/java/net/wurstclient/altmanager/NameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/SkinStealer.java
+++ b/src/main/java/net/wurstclient/altmanager/SkinStealer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/XBoxLiveToken.java
+++ b/src/main/java/net/wurstclient/altmanager/XBoxLiveToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/screens/AddAltScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AddAltScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/screens/AltEditorScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AltEditorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/screens/AltManagerScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AltManagerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/screens/DirectLoginScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/DirectLoginScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/altmanager/screens/EditAltScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/EditAltScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/analytics/AnalyticsConfigFile.java
+++ b/src/main/java/net/wurstclient/analytics/AnalyticsConfigFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/analytics/PlausibleAnalytics.java
+++ b/src/main/java/net/wurstclient/analytics/PlausibleAnalytics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/ClickGui.java
+++ b/src/main/java/net/wurstclient/clickgui/ClickGui.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/ClickGuiIcons.java
+++ b/src/main/java/net/wurstclient/clickgui/ClickGuiIcons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/ComboBoxPopup.java
+++ b/src/main/java/net/wurstclient/clickgui/ComboBoxPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/Component.java
+++ b/src/main/java/net/wurstclient/clickgui/Component.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/Popup.java
+++ b/src/main/java/net/wurstclient/clickgui/Popup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/SettingsWindow.java
+++ b/src/main/java/net/wurstclient/clickgui/SettingsWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/Window.java
+++ b/src/main/java/net/wurstclient/clickgui/Window.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/AbstractListEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/AbstractListEditButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/BlockComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/BlockComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/BlockListEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/BlockListEditButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/BookOffersEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/BookOffersEditButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/CheckboxComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/CheckboxComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/ColorComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/ColorComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/ComboBoxComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/ComboBoxComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/FeatureButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/FeatureButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/FileComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/FileComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/ItemListEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/ItemListEditButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/PlantTypeComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/PlantTypeComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/RadarComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/RadarComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/SliderComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/SliderComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/TextFieldEditButton.java
+++ b/src/main/java/net/wurstclient/clickgui/components/TextFieldEditButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/components/ToggleAllPlantTypesComponent.java
+++ b/src/main/java/net/wurstclient/clickgui/components/ToggleAllPlantTypesComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/AddBookOfferScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/AddBookOfferScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/ClickGuiScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/ClickGuiScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditBlockListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditBlockListScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditBlockScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditBlockScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditBookOfferScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditBookOfferScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditBookOffersScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditBookOffersScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditColorScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditColorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditItemListScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditSliderScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditSliderScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/EditTextFieldScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/EditTextFieldScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/clickgui/screens/SelectFileScreen.java
+++ b/src/main/java/net/wurstclient/clickgui/screens/SelectFileScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/command/CmdError.java
+++ b/src/main/java/net/wurstclient/command/CmdError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/command/CmdException.java
+++ b/src/main/java/net/wurstclient/command/CmdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/command/CmdList.java
+++ b/src/main/java/net/wurstclient/command/CmdList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/command/CmdProcessor.java
+++ b/src/main/java/net/wurstclient/command/CmdProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/command/CmdSyntaxError.java
+++ b/src/main/java/net/wurstclient/command/CmdSyntaxError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/command/Command.java
+++ b/src/main/java/net/wurstclient/command/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/AddAltCmd.java
+++ b/src/main/java/net/wurstclient/commands/AddAltCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/AnnoyCmd.java
+++ b/src/main/java/net/wurstclient/commands/AnnoyCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/AuthorCmd.java
+++ b/src/main/java/net/wurstclient/commands/AuthorCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/BindCmd.java
+++ b/src/main/java/net/wurstclient/commands/BindCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/BindsCmd.java
+++ b/src/main/java/net/wurstclient/commands/BindsCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/BlinkCmd.java
+++ b/src/main/java/net/wurstclient/commands/BlinkCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/BlockListCmd.java
+++ b/src/main/java/net/wurstclient/commands/BlockListCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ClearCmd.java
+++ b/src/main/java/net/wurstclient/commands/ClearCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/CopyItemCmd.java
+++ b/src/main/java/net/wurstclient/commands/CopyItemCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/DamageCmd.java
+++ b/src/main/java/net/wurstclient/commands/DamageCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/DigCmd.java
+++ b/src/main/java/net/wurstclient/commands/DigCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/DropCmd.java
+++ b/src/main/java/net/wurstclient/commands/DropCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/EnabledHaxCmd.java
+++ b/src/main/java/net/wurstclient/commands/EnabledHaxCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/EnchantCmd.java
+++ b/src/main/java/net/wurstclient/commands/EnchantCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ExcavateCmd.java
+++ b/src/main/java/net/wurstclient/commands/ExcavateCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/FeaturesCmd.java
+++ b/src/main/java/net/wurstclient/commands/FeaturesCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/FollowCmd.java
+++ b/src/main/java/net/wurstclient/commands/FollowCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/FriendsCmd.java
+++ b/src/main/java/net/wurstclient/commands/FriendsCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/GetPosCmd.java
+++ b/src/main/java/net/wurstclient/commands/GetPosCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/GiveCmd.java
+++ b/src/main/java/net/wurstclient/commands/GiveCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/GmCmd.java
+++ b/src/main/java/net/wurstclient/commands/GmCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/GoToCmd.java
+++ b/src/main/java/net/wurstclient/commands/GoToCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/HelpCmd.java
+++ b/src/main/java/net/wurstclient/commands/HelpCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/InvseeCmd.java
+++ b/src/main/java/net/wurstclient/commands/InvseeCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/IpCmd.java
+++ b/src/main/java/net/wurstclient/commands/IpCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ItemListCmd.java
+++ b/src/main/java/net/wurstclient/commands/ItemListCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/JumpCmd.java
+++ b/src/main/java/net/wurstclient/commands/JumpCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/LeaveCmd.java
+++ b/src/main/java/net/wurstclient/commands/LeaveCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ModifyCmd.java
+++ b/src/main/java/net/wurstclient/commands/ModifyCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/PathCmd.java
+++ b/src/main/java/net/wurstclient/commands/PathCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/PotionCmd.java
+++ b/src/main/java/net/wurstclient/commands/PotionCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ProtectCmd.java
+++ b/src/main/java/net/wurstclient/commands/ProtectCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/RenameCmd.java
+++ b/src/main/java/net/wurstclient/commands/RenameCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/RepairCmd.java
+++ b/src/main/java/net/wurstclient/commands/RepairCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/RvCmd.java
+++ b/src/main/java/net/wurstclient/commands/RvCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SayCmd.java
+++ b/src/main/java/net/wurstclient/commands/SayCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SetBlockCmd.java
+++ b/src/main/java/net/wurstclient/commands/SetBlockCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SetCheckboxCmd.java
+++ b/src/main/java/net/wurstclient/commands/SetCheckboxCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SetColorCmd.java
+++ b/src/main/java/net/wurstclient/commands/SetColorCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SetModeCmd.java
+++ b/src/main/java/net/wurstclient/commands/SetModeCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SetSliderCmd.java
+++ b/src/main/java/net/wurstclient/commands/SetSliderCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SettingsCmd.java
+++ b/src/main/java/net/wurstclient/commands/SettingsCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/SvCmd.java
+++ b/src/main/java/net/wurstclient/commands/SvCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/TCmd.java
+++ b/src/main/java/net/wurstclient/commands/TCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/TacoCmd.java
+++ b/src/main/java/net/wurstclient/commands/TacoCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/TooManyHaxCmd.java
+++ b/src/main/java/net/wurstclient/commands/TooManyHaxCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/TpCmd.java
+++ b/src/main/java/net/wurstclient/commands/TpCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/UnbindCmd.java
+++ b/src/main/java/net/wurstclient/commands/UnbindCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/VClipCmd.java
+++ b/src/main/java/net/wurstclient/commands/VClipCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ViewCompCmd.java
+++ b/src/main/java/net/wurstclient/commands/ViewCompCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/ViewNbtCmd.java
+++ b/src/main/java/net/wurstclient/commands/ViewNbtCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/commands/XrayCmd.java
+++ b/src/main/java/net/wurstclient/commands/XrayCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/event/CancellableEvent.java
+++ b/src/main/java/net/wurstclient/event/CancellableEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/event/Event.java
+++ b/src/main/java/net/wurstclient/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/event/EventManager.java
+++ b/src/main/java/net/wurstclient/event/EventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/event/Listener.java
+++ b/src/main/java/net/wurstclient/event/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/AirStrafingSpeedListener.java
+++ b/src/main/java/net/wurstclient/events/AirStrafingSpeedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/BlockBreakingProgressListener.java
+++ b/src/main/java/net/wurstclient/events/BlockBreakingProgressListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/CactusCollisionShapeListener.java
+++ b/src/main/java/net/wurstclient/events/CactusCollisionShapeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/CameraTransformViewBobbingListener.java
+++ b/src/main/java/net/wurstclient/events/CameraTransformViewBobbingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/ChatInputListener.java
+++ b/src/main/java/net/wurstclient/events/ChatInputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/ChatOutputListener.java
+++ b/src/main/java/net/wurstclient/events/ChatOutputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/ConnectionPacketOutputListener.java
+++ b/src/main/java/net/wurstclient/events/ConnectionPacketOutputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/DeathListener.java
+++ b/src/main/java/net/wurstclient/events/DeathListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/GUIRenderListener.java
+++ b/src/main/java/net/wurstclient/events/GUIRenderListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/GetAmbientOcclusionLightLevelListener.java
+++ b/src/main/java/net/wurstclient/events/GetAmbientOcclusionLightLevelListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/HandleBlockBreakingListener.java
+++ b/src/main/java/net/wurstclient/events/HandleBlockBreakingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/HandleInputListener.java
+++ b/src/main/java/net/wurstclient/events/HandleInputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/IsNormalCubeListener.java
+++ b/src/main/java/net/wurstclient/events/IsNormalCubeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/IsPlayerInLavaListener.java
+++ b/src/main/java/net/wurstclient/events/IsPlayerInLavaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/IsPlayerInWaterListener.java
+++ b/src/main/java/net/wurstclient/events/IsPlayerInWaterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/KeyPressListener.java
+++ b/src/main/java/net/wurstclient/events/KeyPressListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/KnockbackListener.java
+++ b/src/main/java/net/wurstclient/events/KnockbackListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/LeftClickListener.java
+++ b/src/main/java/net/wurstclient/events/LeftClickListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/MouseScrollListener.java
+++ b/src/main/java/net/wurstclient/events/MouseScrollListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/MouseUpdateListener.java
+++ b/src/main/java/net/wurstclient/events/MouseUpdateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/PacketInputListener.java
+++ b/src/main/java/net/wurstclient/events/PacketInputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/PacketOutputListener.java
+++ b/src/main/java/net/wurstclient/events/PacketOutputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/PlayerAttacksEntityListener.java
+++ b/src/main/java/net/wurstclient/events/PlayerAttacksEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/PlayerMoveListener.java
+++ b/src/main/java/net/wurstclient/events/PlayerMoveListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/PostMotionListener.java
+++ b/src/main/java/net/wurstclient/events/PostMotionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/PreMotionListener.java
+++ b/src/main/java/net/wurstclient/events/PreMotionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/RenderBlockEntityListener.java
+++ b/src/main/java/net/wurstclient/events/RenderBlockEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/RenderListener.java
+++ b/src/main/java/net/wurstclient/events/RenderListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/RightClickListener.java
+++ b/src/main/java/net/wurstclient/events/RightClickListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/SetOpaqueCubeListener.java
+++ b/src/main/java/net/wurstclient/events/SetOpaqueCubeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/ShouldDrawSideListener.java
+++ b/src/main/java/net/wurstclient/events/ShouldDrawSideListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/StopUsingItemListener.java
+++ b/src/main/java/net/wurstclient/events/StopUsingItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/UpdateListener.java
+++ b/src/main/java/net/wurstclient/events/UpdateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/VelocityFromEntityCollisionListener.java
+++ b/src/main/java/net/wurstclient/events/VelocityFromEntityCollisionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/events/VelocityFromFluidListener.java
+++ b/src/main/java/net/wurstclient/events/VelocityFromFluidListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hack/DontSaveState.java
+++ b/src/main/java/net/wurstclient/hack/DontSaveState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hack/EnabledHacksFile.java
+++ b/src/main/java/net/wurstclient/hack/EnabledHacksFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hack/Hack.java
+++ b/src/main/java/net/wurstclient/hack/Hack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AimAssistHack.java
+++ b/src/main/java/net/wurstclient/hacks/AimAssistHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
+++ b/src/main/java/net/wurstclient/hacks/AirPlaceHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AnchorAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/AnchorAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiAfkHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiAfkHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiBlindHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiBlindHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiCactusHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiCactusHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiEntityPushHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiEntityPushHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiHungerHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiHungerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiKnockbackHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiKnockbackHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiSpamHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiSpamHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiWaterPushHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AntiWobbleHack.java
+++ b/src/main/java/net/wurstclient/hacks/AntiWobbleHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ArrowDmgHack.java
+++ b/src/main/java/net/wurstclient/hacks/ArrowDmgHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoArmorHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoArmorHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoBuildHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoBuildHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoCompleteHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoCompleteHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoDropHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoDropHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoEatHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoEatHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoFarmHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoFarmHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoFishHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoFishHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoLeaveHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoLeaveHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoLibrarianHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoLibrarianHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoMineHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoMineHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoPotionHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoPotionHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoReconnectHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoReconnectHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoRespawnHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoRespawnHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoSignHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSignHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoSoupHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSoupHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoSprintHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSprintHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoStealHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoStealHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoSwimHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSwimHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoSwitchHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSwitchHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoSwordHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoSwordHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoToolHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoToolHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoTotemHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoTotemHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/AutoWalkHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoWalkHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BarrierEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/BarrierEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BaseFinderHack.java
+++ b/src/main/java/net/wurstclient/hacks/BaseFinderHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BlinkHack.java
+++ b/src/main/java/net/wurstclient/hacks/BlinkHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BoatFlyHack.java
+++ b/src/main/java/net/wurstclient/hacks/BoatFlyHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BonemealAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/BonemealAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BowAimbotHack.java
+++ b/src/main/java/net/wurstclient/hacks/BowAimbotHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BuildRandomHack.java
+++ b/src/main/java/net/wurstclient/hacks/BuildRandomHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/BunnyHopHack.java
+++ b/src/main/java/net/wurstclient/hacks/BunnyHopHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CameraDistanceHack.java
+++ b/src/main/java/net/wurstclient/hacks/CameraDistanceHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CameraNoClipHack.java
+++ b/src/main/java/net/wurstclient/hacks/CameraNoClipHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CaveFinderHack.java
+++ b/src/main/java/net/wurstclient/hacks/CaveFinderHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ChatTranslatorHack.java
+++ b/src/main/java/net/wurstclient/hacks/ChatTranslatorHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ChestEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ChestEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ClickAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/ClickAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ClickGuiHack.java
+++ b/src/main/java/net/wurstclient/hacks/ClickGuiHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CrashChestHack.java
+++ b/src/main/java/net/wurstclient/hacks/CrashChestHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CreativeFlightHack.java
+++ b/src/main/java/net/wurstclient/hacks/CreativeFlightHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CriticalsHack.java
+++ b/src/main/java/net/wurstclient/hacks/CriticalsHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/CrystalAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/CrystalAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/DerpHack.java
+++ b/src/main/java/net/wurstclient/hacks/DerpHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/DolphinHack.java
+++ b/src/main/java/net/wurstclient/hacks/DolphinHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ExcavatorHack.java
+++ b/src/main/java/net/wurstclient/hacks/ExcavatorHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ExtraElytraHack.java
+++ b/src/main/java/net/wurstclient/hacks/ExtraElytraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FancyChatHack.java
+++ b/src/main/java/net/wurstclient/hacks/FancyChatHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FastBreakHack.java
+++ b/src/main/java/net/wurstclient/hacks/FastBreakHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FastLadderHack.java
+++ b/src/main/java/net/wurstclient/hacks/FastLadderHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FastPlaceHack.java
+++ b/src/main/java/net/wurstclient/hacks/FastPlaceHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FeedAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/FeedAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FightBotHack.java
+++ b/src/main/java/net/wurstclient/hacks/FightBotHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FishHack.java
+++ b/src/main/java/net/wurstclient/hacks/FishHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FlightHack.java
+++ b/src/main/java/net/wurstclient/hacks/FlightHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FollowHack.java
+++ b/src/main/java/net/wurstclient/hacks/FollowHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ForceOpHack.java
+++ b/src/main/java/net/wurstclient/hacks/ForceOpHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FreecamHack.java
+++ b/src/main/java/net/wurstclient/hacks/FreecamHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/FullbrightHack.java
+++ b/src/main/java/net/wurstclient/hacks/FullbrightHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/GlideHack.java
+++ b/src/main/java/net/wurstclient/hacks/GlideHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/HandNoClipHack.java
+++ b/src/main/java/net/wurstclient/hacks/HandNoClipHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/HeadRollHack.java
+++ b/src/main/java/net/wurstclient/hacks/HeadRollHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/HealthTagsHack.java
+++ b/src/main/java/net/wurstclient/hacks/HealthTagsHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/HighJumpHack.java
+++ b/src/main/java/net/wurstclient/hacks/HighJumpHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/InfiniChatHack.java
+++ b/src/main/java/net/wurstclient/hacks/InfiniChatHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/InstaBuildHack.java
+++ b/src/main/java/net/wurstclient/hacks/InstaBuildHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/InstantBunkerHack.java
+++ b/src/main/java/net/wurstclient/hacks/InstantBunkerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/InvWalkHack.java
+++ b/src/main/java/net/wurstclient/hacks/InvWalkHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ItemGeneratorHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemGeneratorHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/JesusHack.java
+++ b/src/main/java/net/wurstclient/hacks/JesusHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/JetpackHack.java
+++ b/src/main/java/net/wurstclient/hacks/JetpackHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/KaboomHack.java
+++ b/src/main/java/net/wurstclient/hacks/KaboomHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/KillPotionHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillPotionHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/KillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/KillauraLegitHack.java
+++ b/src/main/java/net/wurstclient/hacks/KillauraLegitHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/LiquidsHack.java
+++ b/src/main/java/net/wurstclient/hacks/LiquidsHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/LsdHack.java
+++ b/src/main/java/net/wurstclient/hacks/LsdHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/MaceDmgHack.java
+++ b/src/main/java/net/wurstclient/hacks/MaceDmgHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/MassTpaHack.java
+++ b/src/main/java/net/wurstclient/hacks/MassTpaHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/MileyCyrusHack.java
+++ b/src/main/java/net/wurstclient/hacks/MileyCyrusHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/MobEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/MobEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/MobSpawnEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/MobSpawnEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/MultiAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/MultiAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NameProtectHack.java
+++ b/src/main/java/net/wurstclient/hacks/NameProtectHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NameTagsHack.java
+++ b/src/main/java/net/wurstclient/hacks/NameTagsHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NavigatorHack.java
+++ b/src/main/java/net/wurstclient/hacks/NavigatorHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NewChunksHack.java
+++ b/src/main/java/net/wurstclient/hacks/NewChunksHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoBackgroundHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoBackgroundHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoClipHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoClipHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoFallHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFallHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFireOverlayHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoFogHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoFogHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoHurtcamHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoHurtcamHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoLevitationHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoLevitationHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoOverlayHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoPumpkinHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoPumpkinHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoShieldOverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoShieldOverlayHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoSlowdownHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoVignetteHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoVignetteHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoWeatherHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoWeatherHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NoWebHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoWebHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NukerHack.java
+++ b/src/main/java/net/wurstclient/hacks/NukerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/NukerLegitHack.java
+++ b/src/main/java/net/wurstclient/hacks/NukerLegitHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/OpenWaterEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/OpenWaterEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/OverlayHack.java
+++ b/src/main/java/net/wurstclient/hacks/OverlayHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/PanicHack.java
+++ b/src/main/java/net/wurstclient/hacks/PanicHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ParkourHack.java
+++ b/src/main/java/net/wurstclient/hacks/ParkourHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/PlayerEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/PlayerEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/PortalEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/PortalEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/PortalGuiHack.java
+++ b/src/main/java/net/wurstclient/hacks/PortalGuiHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/PotionSaverHack.java
+++ b/src/main/java/net/wurstclient/hacks/PotionSaverHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ProphuntEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ProphuntEspHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ProtectHack.java
+++ b/src/main/java/net/wurstclient/hacks/ProtectHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/RadarHack.java
+++ b/src/main/java/net/wurstclient/hacks/RadarHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/RainbowUiHack.java
+++ b/src/main/java/net/wurstclient/hacks/RainbowUiHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ReachHack.java
+++ b/src/main/java/net/wurstclient/hacks/ReachHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/RemoteViewHack.java
+++ b/src/main/java/net/wurstclient/hacks/RemoteViewHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/RestockHack.java
+++ b/src/main/java/net/wurstclient/hacks/RestockHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SafeWalkHack.java
+++ b/src/main/java/net/wurstclient/hacks/SafeWalkHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ScaffoldWalkHack.java
+++ b/src/main/java/net/wurstclient/hacks/ScaffoldWalkHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SearchHack.java
+++ b/src/main/java/net/wurstclient/hacks/SearchHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SkinDerpHack.java
+++ b/src/main/java/net/wurstclient/hacks/SkinDerpHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SneakHack.java
+++ b/src/main/java/net/wurstclient/hacks/SneakHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SnowShoeHack.java
+++ b/src/main/java/net/wurstclient/hacks/SnowShoeHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SpeedHackHack.java
+++ b/src/main/java/net/wurstclient/hacks/SpeedHackHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SpeedNukerHack.java
+++ b/src/main/java/net/wurstclient/hacks/SpeedNukerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/SpiderHack.java
+++ b/src/main/java/net/wurstclient/hacks/SpiderHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/StepHack.java
+++ b/src/main/java/net/wurstclient/hacks/StepHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TemplateToolHack.java
+++ b/src/main/java/net/wurstclient/hacks/TemplateToolHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/ThrowHack.java
+++ b/src/main/java/net/wurstclient/hacks/ThrowHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TillauraHack.java
+++ b/src/main/java/net/wurstclient/hacks/TillauraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TimerHack.java
+++ b/src/main/java/net/wurstclient/hacks/TimerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TiredHack.java
+++ b/src/main/java/net/wurstclient/hacks/TiredHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TooManyHaxHack.java
+++ b/src/main/java/net/wurstclient/hacks/TooManyHaxHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TpAuraHack.java
+++ b/src/main/java/net/wurstclient/hacks/TpAuraHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TrajectoriesHack.java
+++ b/src/main/java/net/wurstclient/hacks/TrajectoriesHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TreeBotHack.java
+++ b/src/main/java/net/wurstclient/hacks/TreeBotHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TriggerBotHack.java
+++ b/src/main/java/net/wurstclient/hacks/TriggerBotHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TrollPotionHack.java
+++ b/src/main/java/net/wurstclient/hacks/TrollPotionHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TrueSightHack.java
+++ b/src/main/java/net/wurstclient/hacks/TrueSightHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/TunnellerHack.java
+++ b/src/main/java/net/wurstclient/hacks/TunnellerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/VeinMinerHack.java
+++ b/src/main/java/net/wurstclient/hacks/VeinMinerHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/XRayHack.java
+++ b/src/main/java/net/wurstclient/hacks/XRayHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autocomplete/MessageCompleter.java
+++ b/src/main/java/net/wurstclient/hacks/autocomplete/MessageCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autocomplete/ModelSettings.java
+++ b/src/main/java/net/wurstclient/hacks/autocomplete/ModelSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autocomplete/OpenAiMessageCompleter.java
+++ b/src/main/java/net/wurstclient/hacks/autocomplete/OpenAiMessageCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autocomplete/SuggestionHandler.java
+++ b/src/main/java/net/wurstclient/hacks/autocomplete/SuggestionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/AutoFarmPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/AutoFarmPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/AutoFarmPlantTypeManager.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/AutoFarmPlantTypeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/AutoFarmRenderer.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/AutoFarmRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/AmethystPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/AmethystPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/BambooPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/BambooPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/BeetrootsPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/BeetrootsPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/CactusPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/CactusPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/CarrotsPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/CarrotsPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/ChorusPlantPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/ChorusPlantPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/CocoaBeanPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/CocoaBeanPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/GlowBerryPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/GlowBerryPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/KelpPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/KelpPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/MelonPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/MelonPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/NetherWartPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/NetherWartPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/PitcherPlantPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/PitcherPlantPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/PotatoesPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/PotatoesPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/PumpkinPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/PumpkinPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/SugarCanePlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/SugarCanePlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/SweetBerryPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/SweetBerryPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/TorchflowerPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/TorchflowerPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/TwistingVinesPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/TwistingVinesPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/WeepingVinesPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/WeepingVinesPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofarm/plants/WheatPlantType.java
+++ b/src/main/java/net/wurstclient/hacks/autofarm/plants/WheatPlantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofish/AutoFishDebugDraw.java
+++ b/src/main/java/net/wurstclient/hacks/autofish/AutoFishDebugDraw.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofish/AutoFishRodSelector.java
+++ b/src/main/java/net/wurstclient/hacks/autofish/AutoFishRodSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofish/FishingSpot.java
+++ b/src/main/java/net/wurstclient/hacks/autofish/FishingSpot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofish/FishingSpotManager.java
+++ b/src/main/java/net/wurstclient/hacks/autofish/FishingSpotManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofish/PositionAndRotation.java
+++ b/src/main/java/net/wurstclient/hacks/autofish/PositionAndRotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autofish/ShallowWaterWarningCheckbox.java
+++ b/src/main/java/net/wurstclient/hacks/autofish/ShallowWaterWarningCheckbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autolibrarian/BookOffer.java
+++ b/src/main/java/net/wurstclient/hacks/autolibrarian/BookOffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/autolibrarian/UpdateBooksSetting.java
+++ b/src/main/java/net/wurstclient/hacks/autolibrarian/UpdateBooksSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chattranslator/FilterOwnMessagesSetting.java
+++ b/src/main/java/net/wurstclient/hacks/chattranslator/FilterOwnMessagesSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chattranslator/GoogleTranslate.java
+++ b/src/main/java/net/wurstclient/hacks/chattranslator/GoogleTranslate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chattranslator/LanguageSetting.java
+++ b/src/main/java/net/wurstclient/hacks/chattranslator/LanguageSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chattranslator/WhatToTranslateSetting.java
+++ b/src/main/java/net/wurstclient/hacks/chattranslator/WhatToTranslateSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/ChestEspBlockGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/ChestEspBlockGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/ChestEspEntityGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/ChestEspEntityGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/ChestEspGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/ChestEspGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/ChestEspGroupManager.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/ChestEspGroupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/BarrelsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/BarrelsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/ChestBoatsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/ChestBoatsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/ChestCartsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/ChestCartsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/CraftersGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/CraftersGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/DispensersGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/DispensersGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/DroppersGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/DroppersGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/EnderChestsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/EnderChestsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/FurnacesGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/FurnacesGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/HopperCartsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/HopperCartsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/HoppersGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/HoppersGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/NormalChestsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/NormalChestsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/PotsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/PotsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/ShulkerBoxesGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/ShulkerBoxesGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/chestesp/groups/TrapChestsGroup.java
+++ b/src/main/java/net/wurstclient/hacks/chestesp/groups/TrapChestsGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/mobspawnesp/HitboxCheckSetting.java
+++ b/src/main/java/net/wurstclient/hacks/mobspawnesp/HitboxCheckSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksChunkRenderer.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksChunkRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksOutlineRenderer.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksOutlineRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksReasonsRenderer.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksReasonsRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksRenderer.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksShowSetting.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksShowSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksSquareRenderer.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksSquareRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/newchunks/NewChunksStyleSetting.java
+++ b/src/main/java/net/wurstclient/hacks/newchunks/NewChunksStyleSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/nukers/CommonNukerSettings.java
+++ b/src/main/java/net/wurstclient/hacks/nukers/CommonNukerSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/nukers/NukerModeSetting.java
+++ b/src/main/java/net/wurstclient/hacks/nukers/NukerModeSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/nukers/NukerMultiIdListSetting.java
+++ b/src/main/java/net/wurstclient/hacks/nukers/NukerMultiIdListSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/nukers/NukerShapeSetting.java
+++ b/src/main/java/net/wurstclient/hacks/nukers/NukerShapeSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/portalesp/PortalEspBlockGroup.java
+++ b/src/main/java/net/wurstclient/hacks/portalesp/PortalEspBlockGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/SelectPositionState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/SelectPositionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/TemplateToolState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/TemplateToolState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/ChooseNameState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/ChooseNameState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/CreatingTemplateState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/CreatingTemplateState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/SavingFileState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/SavingFileState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/ScanningAreaState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/ScanningAreaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/SelectBoxEndState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/SelectBoxEndState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/SelectBoxStartState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/SelectBoxStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/templatetool/states/SelectOriginState.java
+++ b/src/main/java/net/wurstclient/hacks/templatetool/states/SelectOriginState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/treebot/Tree.java
+++ b/src/main/java/net/wurstclient/hacks/treebot/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hacks/treebot/TreeBotUtils.java
+++ b/src/main/java/net/wurstclient/hacks/treebot/TreeBotUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hud/HackListHUD.java
+++ b/src/main/java/net/wurstclient/hud/HackListHUD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hud/IngameHUD.java
+++ b/src/main/java/net/wurstclient/hud/IngameHUD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hud/TabGui.java
+++ b/src/main/java/net/wurstclient/hud/TabGui.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/hud/WurstLogo.java
+++ b/src/main/java/net/wurstclient/hud/WurstLogo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/keybinds/Keybind.java
+++ b/src/main/java/net/wurstclient/keybinds/Keybind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/keybinds/KeybindList.java
+++ b/src/main/java/net/wurstclient/keybinds/KeybindList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/keybinds/KeybindProcessor.java
+++ b/src/main/java/net/wurstclient/keybinds/KeybindProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/keybinds/KeybindsFile.java
+++ b/src/main/java/net/wurstclient/keybinds/KeybindsFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/keybinds/PossibleKeybind.java
+++ b/src/main/java/net/wurstclient/keybinds/PossibleKeybind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/net/wurstclient/mixin/AbstractBlockStateMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/AbstractSignEditScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/AbstractSignEditScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/AllowedAddressResolverMixin.java
+++ b/src/main/java/net/wurstclient/mixin/AllowedAddressResolverMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/AtmosphericFogModifierMixin.java
+++ b/src/main/java/net/wurstclient/mixin/AtmosphericFogModifierMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/BlockEntityRenderDispatcherMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockEntityRenderDispatcherMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/BlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/BlockModelRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockModelRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/CactusBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/CactusBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/CameraMixin.java
+++ b/src/main/java/net/wurstclient/mixin/CameraMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ChatHudMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ChatHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ChatInputSuggestorMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ChatInputSuggestorMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ChatScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ChatScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ChunkOcclusionGraphBuilderMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ChunkOcclusionGraphBuilderMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ClientCommonNetworkHandlerMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientCommonNetworkHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientConnectionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientPlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ClientWorldMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientWorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ControlsListWidgetMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ControlsListWidgetMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/CreativeInventoryScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/DeathScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DeathScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/DimensionOrBossFogModifierMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DimensionOrBossFogModifierMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/DirectConnectScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DirectConnectScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DisconnectedScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/DownloaderMixin.java
+++ b/src/main/java/net/wurstclient/mixin/DownloaderMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/EntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/EntityRenderDispatcherMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityRenderDispatcherMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/EntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/FogRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/FogRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameMenuScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/GameRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GameRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/GenericContainerScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/GenericContainerScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/HeldItemRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/HeldItemRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/InGameOverlayRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/IngameHudMixin.java
+++ b/src/main/java/net/wurstclient/mixin/IngameHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/KeyBindingMixin.java
+++ b/src/main/java/net/wurstclient/mixin/KeyBindingMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/KeyboardMixin.java
+++ b/src/main/java/net/wurstclient/mixin/KeyboardMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/LanguageManagerMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LanguageManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LivingEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MinecraftClientMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/MobEntityRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MobEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/MouseMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MouseMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MultiplayerScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/PackScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/PackScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/PlayerSkinProviderMixin.java
+++ b/src/main/java/net/wurstclient/mixin/PlayerSkinProviderMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/PowderSnowBlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/PowderSnowBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/RenderLayersMixin.java
+++ b/src/main/java/net/wurstclient/mixin/RenderLayersMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/RenderTickCounterDynamicMixin.java
+++ b/src/main/java/net/wurstclient/mixin/RenderTickCounterDynamicMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/ShulkerBoxScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ShulkerBoxScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/SimpleOptionMixin.java
+++ b/src/main/java/net/wurstclient/mixin/SimpleOptionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/StatsScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/StatsScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/StatusEffectInstanceMixin.java
+++ b/src/main/java/net/wurstclient/mixin/StatusEffectInstanceMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/TelemetryManagerMixin.java
+++ b/src/main/java/net/wurstclient/mixin/TelemetryManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/TextVisitFactoryMixin.java
+++ b/src/main/java/net/wurstclient/mixin/TextVisitFactoryMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/TitleScreenMixin.java
+++ b/src/main/java/net/wurstclient/mixin/TitleScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/WorldMixin.java
+++ b/src/main/java/net/wurstclient/mixin/WorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/WorldRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/indigo/AbstractTerrainRenderContextMixin.java
+++ b/src/main/java/net/wurstclient/mixin/indigo/AbstractTerrainRenderContextMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/indigo/BlockRenderInfoMixin.java
+++ b/src/main/java/net/wurstclient/mixin/indigo/BlockRenderInfoMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/sodium/AbstractBlockRenderContextMixin.java
+++ b/src/main/java/net/wurstclient/mixin/sodium/AbstractBlockRenderContextMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/sodium/BlockRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/sodium/BlockRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixin/sodium/DefaultFluidRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/sodium/DefaultFluidRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixinterface/IClientPlayerEntity.java
+++ b/src/main/java/net/wurstclient/mixinterface/IClientPlayerEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixinterface/IClientPlayerInteractionManager.java
+++ b/src/main/java/net/wurstclient/mixinterface/IClientPlayerInteractionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixinterface/IKeyBinding.java
+++ b/src/main/java/net/wurstclient/mixinterface/IKeyBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixinterface/IMinecraftClient.java
+++ b/src/main/java/net/wurstclient/mixinterface/IMinecraftClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/mixinterface/ISimpleOption.java
+++ b/src/main/java/net/wurstclient/mixinterface/ISimpleOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/Navigator.java
+++ b/src/main/java/net/wurstclient/navigator/Navigator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/NavigatorFeatureScreen.java
+++ b/src/main/java/net/wurstclient/navigator/NavigatorFeatureScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/NavigatorMainScreen.java
+++ b/src/main/java/net/wurstclient/navigator/NavigatorMainScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/NavigatorNewKeybindScreen.java
+++ b/src/main/java/net/wurstclient/navigator/NavigatorNewKeybindScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/NavigatorRemoveKeybindScreen.java
+++ b/src/main/java/net/wurstclient/navigator/NavigatorRemoveKeybindScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/NavigatorScreen.java
+++ b/src/main/java/net/wurstclient/navigator/NavigatorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/navigator/PreferencesFile.java
+++ b/src/main/java/net/wurstclient/navigator/PreferencesFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/nochatreports/ForcedChatReportsScreen.java
+++ b/src/main/java/net/wurstclient/nochatreports/ForcedChatReportsScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/nochatreports/NcrModRequiredScreen.java
+++ b/src/main/java/net/wurstclient/nochatreports/NcrModRequiredScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/EnterProfileNameScreen.java
+++ b/src/main/java/net/wurstclient/options/EnterProfileNameScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/KeybindEditorScreen.java
+++ b/src/main/java/net/wurstclient/options/KeybindEditorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/KeybindManagerScreen.java
+++ b/src/main/java/net/wurstclient/options/KeybindManagerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/KeybindProfilesScreen.java
+++ b/src/main/java/net/wurstclient/options/KeybindProfilesScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/PressAKeyCallback.java
+++ b/src/main/java/net/wurstclient/options/PressAKeyCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/PressAKeyScreen.java
+++ b/src/main/java/net/wurstclient/options/PressAKeyScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/WurstOptionsScreen.java
+++ b/src/main/java/net/wurstclient/options/WurstOptionsScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/options/ZoomManagerScreen.java
+++ b/src/main/java/net/wurstclient/options/ZoomManagerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_feature/OtfList.java
+++ b/src/main/java/net/wurstclient/other_feature/OtfList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_feature/OtherFeature.java
+++ b/src/main/java/net/wurstclient/other_feature/OtherFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/ChangelogOtf.java
+++ b/src/main/java/net/wurstclient/other_features/ChangelogOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/CleanUpOtf.java
+++ b/src/main/java/net/wurstclient/other_features/CleanUpOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/DisableOtf.java
+++ b/src/main/java/net/wurstclient/other_features/DisableOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/HackListOtf.java
+++ b/src/main/java/net/wurstclient/other_features/HackListOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/KeybindManagerOtf.java
+++ b/src/main/java/net/wurstclient/other_features/KeybindManagerOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/LastServerOtf.java
+++ b/src/main/java/net/wurstclient/other_features/LastServerOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/NoChatReportsOtf.java
+++ b/src/main/java/net/wurstclient/other_features/NoChatReportsOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/NoTelemetryOtf.java
+++ b/src/main/java/net/wurstclient/other_features/NoTelemetryOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/ReconnectOtf.java
+++ b/src/main/java/net/wurstclient/other_features/ReconnectOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/ServerFinderOtf.java
+++ b/src/main/java/net/wurstclient/other_features/ServerFinderOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/TabGuiOtf.java
+++ b/src/main/java/net/wurstclient/other_features/TabGuiOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/TranslationsOtf.java
+++ b/src/main/java/net/wurstclient/other_features/TranslationsOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/VanillaSpoofOtf.java
+++ b/src/main/java/net/wurstclient/other_features/VanillaSpoofOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/WikiDataExportOtf.java
+++ b/src/main/java/net/wurstclient/other_features/WikiDataExportOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/WurstCapesOtf.java
+++ b/src/main/java/net/wurstclient/other_features/WurstCapesOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/WurstLogoOtf.java
+++ b/src/main/java/net/wurstclient/other_features/WurstLogoOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/other_features/ZoomOtf.java
+++ b/src/main/java/net/wurstclient/other_features/ZoomOtf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/serverfinder/CleanUpScreen.java
+++ b/src/main/java/net/wurstclient/serverfinder/CleanUpScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/serverfinder/ServerFinderScreen.java
+++ b/src/main/java/net/wurstclient/serverfinder/ServerFinderScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/serverfinder/WurstServerPinger.java
+++ b/src/main/java/net/wurstclient/serverfinder/WurstServerPinger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/AimAtSetting.java
+++ b/src/main/java/net/wurstclient/settings/AimAtSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/AttackSpeedSliderSetting.java
+++ b/src/main/java/net/wurstclient/settings/AttackSpeedSliderSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/BlockListSetting.java
+++ b/src/main/java/net/wurstclient/settings/BlockListSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/BlockSetting.java
+++ b/src/main/java/net/wurstclient/settings/BlockSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/BookOffersSetting.java
+++ b/src/main/java/net/wurstclient/settings/BookOffersSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/CheckboxLock.java
+++ b/src/main/java/net/wurstclient/settings/CheckboxLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/CheckboxSetting.java
+++ b/src/main/java/net/wurstclient/settings/CheckboxSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/ChunkAreaSetting.java
+++ b/src/main/java/net/wurstclient/settings/ChunkAreaSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/ColorSetting.java
+++ b/src/main/java/net/wurstclient/settings/ColorSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/EnumSetting.java
+++ b/src/main/java/net/wurstclient/settings/EnumSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/EspBoxSizeSetting.java
+++ b/src/main/java/net/wurstclient/settings/EspBoxSizeSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/EspStyleSetting.java
+++ b/src/main/java/net/wurstclient/settings/EspStyleSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/FaceTargetSetting.java
+++ b/src/main/java/net/wurstclient/settings/FaceTargetSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/FileSetting.java
+++ b/src/main/java/net/wurstclient/settings/FileSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/ItemListSetting.java
+++ b/src/main/java/net/wurstclient/settings/ItemListSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/PauseAttackOnContainersSetting.java
+++ b/src/main/java/net/wurstclient/settings/PauseAttackOnContainersSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/PlantTypeSetting.java
+++ b/src/main/java/net/wurstclient/settings/PlantTypeSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/RoundingPrecisionSetting.java
+++ b/src/main/java/net/wurstclient/settings/RoundingPrecisionSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/Setting.java
+++ b/src/main/java/net/wurstclient/settings/Setting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/SettingsFile.java
+++ b/src/main/java/net/wurstclient/settings/SettingsFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/SliderLock.java
+++ b/src/main/java/net/wurstclient/settings/SliderLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/SliderSetting.java
+++ b/src/main/java/net/wurstclient/settings/SliderSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/SwingHandSetting.java
+++ b/src/main/java/net/wurstclient/settings/SwingHandSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/TextFieldSetting.java
+++ b/src/main/java/net/wurstclient/settings/TextFieldSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/ToggleAllPlantTypesSetting.java
+++ b/src/main/java/net/wurstclient/settings/ToggleAllPlantTypesSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filterlists/AnchorAuraFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/AnchorAuraFilterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filterlists/CrystalAuraFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/CrystalAuraFilterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/EntityFilterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filterlists/FollowFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/FollowFilterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filterlists/RemoteViewFilterList.java
+++ b/src/main/java/net/wurstclient/settings/filterlists/RemoteViewFilterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/AttackDetectingEntityFilter.java
+++ b/src/main/java/net/wurstclient/settings/filters/AttackDetectingEntityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/EntityFilterCheckbox.java
+++ b/src/main/java/net/wurstclient/settings/filters/EntityFilterCheckbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterAllaysSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterAllaysSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterArmorStandsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterArmorStandsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterBabiesSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterBabiesSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterBatsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterBatsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterCrystalsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterCrystalsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterEndermenSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterEndermenSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterFlyingSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterFlyingSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterGolemsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterGolemsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterHostileSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterHostileSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterInvisibleSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterInvisibleSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterMinecartsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterMinecartsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterNamedSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterNamedSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterNeutralSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterNeutralSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterPassiveSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPassiveSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterPassiveWaterSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPassiveWaterSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterPetsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPetsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterPiglinsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPiglinsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterPlayersSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterPlayersSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterShulkerBulletSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterShulkerBulletSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterShulkersSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterShulkersSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterSleepingSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterSleepingSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterSlimesSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterSlimesSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterVillagersSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterVillagersSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterZombiePiglinsSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterZombiePiglinsSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/settings/filters/FilterZombieVillagersSetting.java
+++ b/src/main/java/net/wurstclient/settings/filters/FilterZombieVillagersSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/update/ProblematicResourcePackDetector.java
+++ b/src/main/java/net/wurstclient/update/ProblematicResourcePackDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/update/Version.java
+++ b/src/main/java/net/wurstclient/update/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/update/WurstUpdater.java
+++ b/src/main/java/net/wurstclient/update/WurstUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/AutoBuildTemplate.java
+++ b/src/main/java/net/wurstclient/util/AutoBuildTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/BlockBreaker.java
+++ b/src/main/java/net/wurstclient/util/BlockBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/BlockBreakingCache.java
+++ b/src/main/java/net/wurstclient/util/BlockBreakingCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/BlockPlacer.java
+++ b/src/main/java/net/wurstclient/util/BlockPlacer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/BlockUtils.java
+++ b/src/main/java/net/wurstclient/util/BlockUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/BlockVertexCompiler.java
+++ b/src/main/java/net/wurstclient/util/BlockVertexCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/BufferWithLayer.java
+++ b/src/main/java/net/wurstclient/util/BufferWithLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/ChatUtils.java
+++ b/src/main/java/net/wurstclient/util/ChatUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/CmdUtils.java
+++ b/src/main/java/net/wurstclient/util/CmdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/ColorUtils.java
+++ b/src/main/java/net/wurstclient/util/ColorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/CustomQuadRenderState.java
+++ b/src/main/java/net/wurstclient/util/CustomQuadRenderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/DefaultAutoBuildTemplates.java
+++ b/src/main/java/net/wurstclient/util/DefaultAutoBuildTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/EasyVertexBuffer.java
+++ b/src/main/java/net/wurstclient/util/EasyVertexBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/EntityUtils.java
+++ b/src/main/java/net/wurstclient/util/EntityUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/FakePlayerEntity.java
+++ b/src/main/java/net/wurstclient/util/FakePlayerEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/ForceOpDialog.java
+++ b/src/main/java/net/wurstclient/util/ForceOpDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/InteractionSimulator.java
+++ b/src/main/java/net/wurstclient/util/InteractionSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/InventoryUtils.java
+++ b/src/main/java/net/wurstclient/util/InventoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/ItemUtils.java
+++ b/src/main/java/net/wurstclient/util/ItemUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/JustGiveMeTheStringVisitor.java
+++ b/src/main/java/net/wurstclient/util/JustGiveMeTheStringVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/LastServerRememberer.java
+++ b/src/main/java/net/wurstclient/util/LastServerRememberer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/LootrModCompat.java
+++ b/src/main/java/net/wurstclient/util/LootrModCompat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/MathUtils.java
+++ b/src/main/java/net/wurstclient/util/MathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/MinPriorityThreadFactory.java
+++ b/src/main/java/net/wurstclient/util/MinPriorityThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/MultiProcessingUtils.java
+++ b/src/main/java/net/wurstclient/util/MultiProcessingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/OverlayRenderer.java
+++ b/src/main/java/net/wurstclient/util/OverlayRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/PacketUtils.java
+++ b/src/main/java/net/wurstclient/util/PacketUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/RegionPos.java
+++ b/src/main/java/net/wurstclient/util/RegionPos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/RenderUtils.java
+++ b/src/main/java/net/wurstclient/util/RenderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/Rotation.java
+++ b/src/main/java/net/wurstclient/util/Rotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/RotationUtils.java
+++ b/src/main/java/net/wurstclient/util/RotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/StreamUtils.java
+++ b/src/main/java/net/wurstclient/util/StreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/SwingUtils.java
+++ b/src/main/java/net/wurstclient/util/SwingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/WurstColors.java
+++ b/src/main/java/net/wurstclient/util/WurstColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/chunk/AbstractChunkCoordinator.java
+++ b/src/main/java/net/wurstclient/util/chunk/AbstractChunkCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/chunk/ChunkSearcher.java
+++ b/src/main/java/net/wurstclient/util/chunk/ChunkSearcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/chunk/ChunkSearcherCoordinator.java
+++ b/src/main/java/net/wurstclient/util/chunk/ChunkSearcherCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/chunk/ChunkUtils.java
+++ b/src/main/java/net/wurstclient/util/chunk/ChunkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/chunk/ChunkVertexBufferCoordinator.java
+++ b/src/main/java/net/wurstclient/util/chunk/ChunkVertexBufferCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/json/JsonException.java
+++ b/src/main/java/net/wurstclient/util/json/JsonException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/json/JsonUtils.java
+++ b/src/main/java/net/wurstclient/util/json/JsonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/json/WsonArray.java
+++ b/src/main/java/net/wurstclient/util/json/WsonArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/json/WsonObject.java
+++ b/src/main/java/net/wurstclient/util/json/WsonObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/text/WLiteralTextContent.java
+++ b/src/main/java/net/wurstclient/util/text/WLiteralTextContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/text/WText.java
+++ b/src/main/java/net/wurstclient/util/text/WText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/text/WTextContent.java
+++ b/src/main/java/net/wurstclient/util/text/WTextContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/main/java/net/wurstclient/util/text/WTranslatedTextContent.java
+++ b/src/main/java/net/wurstclient/util/text/WTranslatedTextContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/test/java/net/wurstclient/util/RotationTest.java
+++ b/src/test/java/net/wurstclient/util/RotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this

--- a/src/test/java/net/wurstclient/util/RotationUtilsTest.java
+++ b/src/test/java/net/wurstclient/util/RotationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Wurst-Imperium and contributors.
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
  *
  * This source code is subject to the terms of the GNU General Public
  * License, version 3. If a copy of the GPL was not distributed with this


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
Spotless is failing due to license header check:

```
Execution failed for task ':spotlessLicenseHeaderCheck'.
> The following files had format violations:
      src/gametest/java/net/wurstclient/gametest/WurstClientTestHelper.java
          @@ -1,5 +1,5 @@
           /*
          -·*·Copyright·(c)·2014-2025·Wurst-Imperium·and·contributors.
          +·*·Copyright·(c)·2014-2026·Wurst-Imperium·and·contributors.
           ·*
           ·*·This·source·code·is·subject·to·the·terms·of·the·GNU·General·Public
           ·*·License,·version·3.·If·a·copy·of·the·GPL·was·not·distributed·with·this
```

## Testing

the following tests succeed:

```
[Wurst7] $ ./gradlew test
Calculating task graph as no cached configuration is available for tasks: test

> Configure project :
Fabric Loom: 1.13.6

BUILD SUCCESSFUL in 3s
4 actionable tasks: 1 executed, 3 up-to-date
Configuration cache entry stored.
```

also, the runClientGameTestWithMods succeeds, but requires fixing imgur for UK devs (is blocked here currently)



## References

This has been updated in master, but missing in 1.21.8