### PR TITLE
Add Baritone Compatibility Mode to Freecam

### DIFF
--- a/src/main/java/net/wurstclient/hacks/FreecamHack.java
+++ b/src/main/java/net/wurstclient/hacks/FreecamHack.java
@@ -8,15 +8,22 @@
 package net.wurstclient.hacks;
 
 import java.awt.Color;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.player.ClientInput;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.world.entity.player.Input;
+import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.util.Mth;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.events.*;
@@ -31,14 +38,20 @@ import net.wurstclient.util.FakePlayerEntity;
 import net.wurstclient.util.RenderUtils;
 
 @DontSaveState
-@SearchTags({"free camera", "spectator"})
+@SearchTags({"free camera", "spectator", "baritone"})
 public final class FreecamHack extends Hack implements UpdateListener,
 	PacketOutputListener, IsPlayerInWaterListener, AirStrafingSpeedListener,
 	IsPlayerInLavaListener, CameraTransformViewBobbingListener,
-	IsNormalCubeListener, SetOpaqueCubeListener, RenderListener
+	IsNormalCubeListener, SetOpaqueCubeListener, RenderListener,
+	MouseUpdateListener, LeftClickListener, RightClickListener
 {
 	private final SliderSetting speed =
 		new SliderSetting("Speed", 1, 0.05, 10, 0.05, ValueDisplay.DECIMAL);
+	
+	private final CheckboxSetting baritoneCompat = new CheckboxSetting(
+		"Baritone Compatibility",
+		"Allows Baritone to control the player while you fly around with the camera.",
+		false);
 	
 	private final CheckboxSetting tracer = new CheckboxSetting("Tracer",
 		"Draws a line to your character's actual position.", false);
@@ -46,15 +59,35 @@ public final class FreecamHack extends Hack implements UpdateListener,
 	private final ColorSetting color =
 		new ColorSetting("Tracer color", Color.WHITE);
 	
+	private static final Field MOVE_VECTOR_FIELD = initMoveVectorField();
+	
 	private FakePlayerEntity fakePlayer;
+	
+	private double camX, camY, camZ;
+	private float camYaw, camPitch;
+	private double prevCamX, prevCamY, prevCamZ;
 	
 	public FreecamHack()
 	{
 		super("Freecam");
 		setCategory(Category.RENDER);
 		addSetting(speed);
+		addSetting(baritoneCompat);
 		addSetting(tracer);
 		addSetting(color);
+	}
+	
+	private static Field initMoveVectorField()
+	{
+		try
+		{
+			Field field = ClientInput.class.getDeclaredField("moveVector");
+			field.setAccessible(true);
+			return field;
+		}catch(ReflectiveOperationException e)
+		{
+			return null;
+		}
 	}
 	
 	@Override
@@ -69,8 +102,24 @@ public final class FreecamHack extends Hack implements UpdateListener,
 		EVENTS.add(IsNormalCubeListener.class, this);
 		EVENTS.add(SetOpaqueCubeListener.class, this);
 		EVENTS.add(RenderListener.class, this);
+		EVENTS.add(MouseUpdateListener.class, this);
+		EVENTS.add(LeftClickListener.class, this);
+		EVENTS.add(RightClickListener.class, this);
 		
-		fakePlayer = new FakePlayerEntity();
+		LocalPlayer player = MC.player;
+		
+		if(baritoneCompat.isChecked())
+		{
+			camX = prevCamX = player.getX();
+			camY = prevCamY = player.getEyeY();
+			camZ = prevCamZ = player.getZ();
+			camYaw = player.getYRot();
+			camPitch = player.getXRot();
+			fakePlayer = null;
+		}else
+		{
+			fakePlayer = new FakePlayerEntity();
+		}
 		
 		Options opt = MC.options;
 		KeyMapping[] bindings = {opt.keyUp, opt.keyDown, opt.keyLeft,
@@ -92,12 +141,17 @@ public final class FreecamHack extends Hack implements UpdateListener,
 		EVENTS.remove(IsNormalCubeListener.class, this);
 		EVENTS.remove(SetOpaqueCubeListener.class, this);
 		EVENTS.remove(RenderListener.class, this);
+		EVENTS.remove(MouseUpdateListener.class, this);
+		EVENTS.remove(LeftClickListener.class, this);
+		EVENTS.remove(RightClickListener.class, this);
 		
-		fakePlayer.resetPlayerPosition();
-		fakePlayer.despawn();
-		
-		LocalPlayer player = MC.player;
-		player.setDeltaMovement(Vec3.ZERO);
+		if(fakePlayer != null)
+		{
+			fakePlayer.resetPlayerPosition();
+			fakePlayer.despawn();
+			fakePlayer = null;
+			MC.player.setDeltaMovement(Vec3.ZERO);
+		}
 		
 		MC.levelRenderer.allChanged();
 	}
@@ -106,28 +160,102 @@ public final class FreecamHack extends Hack implements UpdateListener,
 	public void onUpdate()
 	{
 		LocalPlayer player = MC.player;
-		player.setDeltaMovement(Vec3.ZERO);
-		player.getAbilities().flying = false;
 		
-		player.setOnGround(false);
-		Vec3 velocity = player.getDeltaMovement();
+		if(baritoneCompat.isChecked())
+		{
+			updateCameraMovement();
+			suppressPlayerInput(player);
+		}else
+		{
+			player.setDeltaMovement(Vec3.ZERO);
+			player.getAbilities().flying = false;
+			
+			player.setOnGround(false);
+			Vec3 velocity = player.getDeltaMovement();
+			
+			if(MC.options.keyJump.isDown())
+				player.setDeltaMovement(velocity.add(0, speed.getValue(), 0));
+			
+			if(MC.options.keyShift.isDown())
+				player.setDeltaMovement(
+					velocity.subtract(0, speed.getValue(), 0));
+		}
+	}
+	
+	private void suppressPlayerInput(LocalPlayer player)
+	{
+		if(player.input == null || !isBaritoneMode() || isBaritonePathing())
+			return;
 		
+		if(player.input instanceof ClientInput clientInput)
+			clearClientInput(clientInput);
+		else
+			player.input.keyPresses = Input.EMPTY;
+	}
+	
+	public void clearClientInput(ClientInput clientInput)
+	{
+		if(clientInput == null)
+			return;
+		
+		clientInput.keyPresses = Input.EMPTY;
+		
+		if(MOVE_VECTOR_FIELD != null)
+			try
+			{
+				MOVE_VECTOR_FIELD.set(clientInput, Vec2.ZERO);
+			}catch(IllegalAccessException ignored)
+			{}
+	}
+	
+	private void updateCameraMovement()
+	{
+		prevCamX = camX;
+		prevCamY = camY;
+		prevCamZ = camZ;
+		
+		double forward = 0;
+		double strafe = 0;
+		double vertical = 0;
+		
+		if(MC.options.keyUp.isDown())
+			forward += 1;
+		if(MC.options.keyDown.isDown())
+			forward -= 1;
+		if(MC.options.keyLeft.isDown())
+			strafe += 1;
+		if(MC.options.keyRight.isDown())
+			strafe -= 1;
 		if(MC.options.keyJump.isDown())
-			player.setDeltaMovement(velocity.add(0, speed.getValue(), 0));
-		
+			vertical += 1;
 		if(MC.options.keyShift.isDown())
-			player.setDeltaMovement(velocity.subtract(0, speed.getValue(), 0));
+			vertical -= 1;
+		
+		double yawRad = Math.toRadians(camYaw);
+		double sin = Math.sin(yawRad);
+		double cos = Math.cos(yawRad);
+		
+		double speedVal = speed.getValue();
+		camX += (strafe * cos - forward * sin) * speedVal;
+		camZ += (forward * cos + strafe * sin) * speedVal;
+		camY += vertical * speedVal;
 	}
 	
 	@Override
 	public void onGetAirStrafingSpeed(AirStrafingSpeedEvent event)
 	{
+		if(baritoneCompat.isChecked())
+			return;
+		
 		event.setSpeed(speed.getValueF());
 	}
 	
 	@Override
 	public void onSentPacket(PacketOutputEvent event)
 	{
+		if(baritoneCompat.isChecked())
+			return;
+		
 		if(event.getPacket() instanceof ServerboundMovePlayerPacket)
 			event.cancel();
 	}
@@ -135,12 +263,18 @@ public final class FreecamHack extends Hack implements UpdateListener,
 	@Override
 	public void onIsPlayerInWater(IsPlayerInWaterEvent event)
 	{
+		if(baritoneCompat.isChecked())
+			return;
+		
 		event.setInWater(false);
 	}
 	
 	@Override
 	public void onIsPlayerInLava(IsPlayerInLavaEvent event)
 	{
+		if(baritoneCompat.isChecked())
+			return;
+		
 		event.setInLava(false);
 	}
 	
@@ -165,21 +299,188 @@ public final class FreecamHack extends Hack implements UpdateListener,
 	}
 	
 	@Override
+	public void onMouseUpdate(MouseUpdateEvent event)
+	{
+		if(!baritoneCompat.isChecked())
+			return;
+		
+		if(MC.screen != null)
+			return;
+		
+		double sensitivity = MC.options.sensitivity().get() * 0.6 + 0.2;
+		double sensitivityCubed = sensitivity * sensitivity * sensitivity * 8.0;
+		
+		double deltaX = event.getDeltaX() * sensitivityCubed;
+		double deltaY = event.getDeltaY() * sensitivityCubed;
+		
+		camYaw += (float)deltaX * 0.15f;
+		camPitch = Mth.clamp(camPitch + (float)deltaY * 0.15f, -90.0f, 90.0f);
+		
+		event.setDeltaX(0);
+		event.setDeltaY(0);
+	}
+	
+	@Override
+	public void onLeftClick(LeftClickListener.LeftClickEvent event)
+	{
+		if(!isBaritoneMode() || isBaritonePathing())
+			return;
+		
+		event.cancel();
+	}
+	
+	@Override
+	public void onRightClick(RightClickListener.RightClickEvent event)
+	{
+		if(!isBaritoneMode() || isBaritonePathing())
+			return;
+		
+		event.cancel();
+	}
+	
+	@Override
 	public void onRender(PoseStack matrixStack, float partialTicks)
 	{
-		if(fakePlayer == null || !tracer.isChecked())
+		if(!tracer.isChecked())
 			return;
 		
 		int colorI = color.getColorI(0x80);
+		AABB targetBox;
 		
-		// box
+		if(baritoneCompat.isChecked())
+			targetBox = MC.player.getBoundingBox();
+		else
+		{
+			if(fakePlayer == null)
+				return;
+			targetBox = fakePlayer.getBoundingBox();
+		}
+		
 		double extraSize = 0.05;
-		AABB box = fakePlayer.getBoundingBox().move(0, extraSize, 0)
-			.inflate(extraSize);
+		AABB box = targetBox.move(0, extraSize, 0).inflate(extraSize);
 		RenderUtils.drawOutlinedBox(matrixStack, box, colorI, false);
 		
-		// line
-		RenderUtils.drawTracer(matrixStack, partialTicks,
-			fakePlayer.getBoundingBox().getCenter(), colorI, false);
+		if(baritoneCompat.isChecked())
+		{
+			Vec3 camPos = RenderUtils.getCameraPos();
+			Vec3 lookVec = getLookVecFromRotation(camYaw, camPitch).scale(10);
+			RenderUtils.drawLine(matrixStack, camPos.add(lookVec),
+				targetBox.getCenter(), colorI, false);
+		}else
+		{
+			RenderUtils.drawTracer(matrixStack, partialTicks,
+				targetBox.getCenter(), colorI, false);
+		}
+	}
+	
+	private Vec3 getLookVecFromRotation(float yaw, float pitch)
+	{
+		float pitchRad = pitch * ((float)Math.PI / 180F);
+		float yawRad = -yaw * ((float)Math.PI / 180F);
+		float cosPitch = Mth.cos(pitchRad);
+		float sinPitch = Mth.sin(pitchRad);
+		float cosYaw = Mth.cos(yawRad);
+		float sinYaw = Mth.sin(yawRad);
+		return new Vec3(sinYaw * cosPitch, -sinPitch, cosYaw * cosPitch);
+	}
+	
+	public boolean isBaritoneMode()
+	{
+		return isEnabled() && baritoneCompat.isChecked();
+	}
+	
+	public boolean shouldPreventHotbarScrolling()
+	{
+		return isBaritoneMode();
+	}
+	
+	public boolean isBaritonePathing()
+	{
+		try
+		{
+			Class<?> apiClass = Class.forName("baritone.api.BaritoneAPI");
+			Method getProvider = apiClass.getMethod("getProvider");
+			Object provider = getProvider.invoke(null);
+			if(provider == null)
+				return false;
+			
+			Method getPrimaryBaritone =
+				provider.getClass().getMethod("getPrimaryBaritone");
+			Object baritone = getPrimaryBaritone.invoke(provider);
+			if(baritone == null)
+				return false;
+			
+			Object pathingBehavior = baritone.getClass()
+				.getMethod("getPathingBehavior").invoke(baritone);
+			if(pathingBehavior != null)
+			{
+				Method isPathing =
+					pathingBehavior.getClass().getMethod("isPathing");
+				if(Boolean.TRUE.equals(isPathing.invoke(pathingBehavior)))
+					return true;
+			}
+			
+			try
+			{
+				Object builderProcess = baritone.getClass()
+					.getMethod("getBuilderProcess").invoke(baritone);
+				if(builderProcess != null)
+				{
+					Method isActive =
+						builderProcess.getClass().getMethod("isActive");
+					if(Boolean.TRUE.equals(isActive.invoke(builderProcess)))
+						return true;
+				}
+			}catch(NoSuchMethodException ignored)
+			{}
+			
+			return false;
+		}catch(ClassNotFoundException | NoSuchMethodException
+			| IllegalAccessException | InvocationTargetException e)
+		{
+			return false;
+		}
+	}
+	
+	public double getCamX(float partialTicks)
+	{
+		return prevCamX + (camX - prevCamX) * partialTicks;
+	}
+	
+	public double getCamY(float partialTicks)
+	{
+		return prevCamY + (camY - prevCamY) * partialTicks;
+	}
+	
+	public double getCamZ(float partialTicks)
+	{
+		return prevCamZ + (camZ - prevCamZ) * partialTicks;
+	}
+	
+	public float getCamYaw()
+	{
+		return camYaw;
+	}
+	
+	public void setCamYaw(float yaw)
+	{
+		this.camYaw = yaw;
+	}
+	
+	public float getCamPitch()
+	{
+		return camPitch;
+	}
+	
+	public void setCamPitch(float pitch)
+	{
+		this.camPitch = pitch;
+	}
+	
+	public Vec3 getRealPlayerPos()
+	{
+		if(fakePlayer != null)
+			return fakePlayer.position();
+		return MC.player.position();
 	}
 }

--- a/src/main/java/net/wurstclient/mixin/CameraMixin.java
+++ b/src/main/java/net/wurstclient/mixin/CameraMixin.java
@@ -8,19 +8,31 @@
 package net.wurstclient.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.Camera;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.FogType;
+import net.minecraft.world.phys.Vec3;
 import net.wurstclient.WurstClient;
 import net.wurstclient.hacks.CameraDistanceHack;
+import net.wurstclient.hacks.FreecamHack;
 
 @Mixin(Camera.class)
 public abstract class CameraMixin
 {
+	@Shadow
+	private Vec3 position;
+	
+	@Shadow
+	protected abstract void setRotation(float yaw, float pitch);
+	
 	@ModifyVariable(at = @At("HEAD"),
 		method = "getMaxZoom(F)F",
 		argsOnly = true)
@@ -49,5 +61,27 @@ public abstract class CameraMixin
 	{
 		if(WurstClient.INSTANCE.getHax().noOverlayHack.isEnabled())
 			cir.setReturnValue(FogType.NONE);
+	}
+	
+	@Inject(at = @At("TAIL"),
+		method = "setup(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/Entity;ZZF)V")
+	private void onSetupCamera(Level level, Entity focusedEntity,
+		boolean thirdPerson, boolean inverseView, float tickDelta,
+		CallbackInfo ci)
+	{
+		FreecamHack freecam = WurstClient.INSTANCE.getHax().freecamHack;
+		if(!freecam.isBaritoneMode())
+			return;
+		
+		position = new Vec3(freecam.getCamX(tickDelta),
+			freecam.getCamY(tickDelta), freecam.getCamZ(tickDelta));
+		setRotation(freecam.getCamYaw(), freecam.getCamPitch());
+	}
+	
+	@Inject(at = @At("HEAD"), method = "isDetached()Z", cancellable = true)
+	private void onIsDetached(CallbackInfoReturnable<Boolean> cir)
+	{
+		if(WurstClient.INSTANCE.getHax().freecamHack.isBaritoneMode())
+			cir.setReturnValue(true);
 	}
 }

--- a/src/main/java/net/wurstclient/mixin/ClientInputMixin.java
+++ b/src/main/java/net/wurstclient/mixin/ClientInputMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.player.ClientInput;
+import net.minecraft.world.phys.Vec2;
+import net.wurstclient.WurstClient;
+import net.wurstclient.hacks.FreecamHack;
+
+@Mixin(ClientInput.class)
+public class ClientInputMixin
+{
+	@Inject(at = @At("HEAD"),
+		method = "getMoveVector()Lnet/minecraft/world/phys/Vec2;",
+		cancellable = true)
+	private void onGetMoveVector(CallbackInfoReturnable<Vec2> cir)
+	{
+		FreecamHack freecam = WurstClient.INSTANCE.getHax().freecamHack;
+		if(freecam != null && freecam.isBaritoneMode()
+			&& !freecam.isBaritonePathing())
+			cir.setReturnValue(Vec2.ZERO);
+	}
+	
+	@Inject(at = @At("HEAD"),
+		method = "hasForwardImpulse()Z",
+		cancellable = true)
+	private void onHasForwardImpulse(CallbackInfoReturnable<Boolean> cir)
+	{
+		FreecamHack freecam = WurstClient.INSTANCE.getHax().freecamHack;
+		if(freecam != null && freecam.isBaritoneMode()
+			&& !freecam.isBaritonePathing())
+			cir.setReturnValue(false);
+	}
+}

--- a/src/main/java/net/wurstclient/mixin/MouseMixin.java
+++ b/src/main/java/net/wurstclient/mixin/MouseMixin.java
@@ -52,7 +52,14 @@ public class MouseMixin
 		method = "onScroll(JDD)V")
 	private boolean wrapOnMouseScroll(Inventory inventory, int slot)
 	{
-		return !WurstClient.INSTANCE.getOtfs().zoomOtf
-			.shouldPreventHotbarScrolling();
+		if(WurstClient.INSTANCE.getOtfs().zoomOtf
+			.shouldPreventHotbarScrolling())
+			return false;
+		
+		if(WurstClient.INSTANCE.getHax().freecamHack
+			.shouldPreventHotbarScrolling())
+			return false;
+		
+		return true;
 	}
 }

--- a/src/main/resources/wurst.mixins.json
+++ b/src/main/resources/wurst.mixins.json
@@ -16,6 +16,7 @@
     "ChatHudMixin",
     "ChatInputSuggestorMixin",
     "ChatScreenMixin",
+    "ClientInputMixin",
     "ChunkOcclusionGraphBuilderMixin",
     "ClientCommonNetworkHandlerMixin",
     "ClientConnectionMixin",


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
First of all, I realize that the Wurst and Baritone projects are not officially linked. However, one of the things I've always appreciated about Wurst is how well it integrates with the broader modding ecosystem. I noticed the conflict between Freecam and Baritone a long time ago, but back then I didn't have the skills to tackle it.

I don't consider myself a Java wizard, and I understand that experienced developers might find areas for improvement in my code, but I truly tried to make this implementation as clean, robust, and crash-safe as possible.

### What does it do?
This PR implements a **"Baritone Compatibility Mode"** for Freecam.

Currently, enabling Freecam completely freezes the player's physics and packets (`setDeltaMovement(0)` and `ServerboundMovePlayerPacket` cancellation). This causes Baritone to stop pathing or mining immediately when the user tries to spectate.

### Technical Implementation Details
*   **New "Baritone Compatibility" setting:** When enabled, Freecam uses a hybrid approach. It manages the camera manually (`camX`, `camY`, `camZ` offsets) without spawning a `FakePlayerEntity`. This keeps the real player entity active in the world context.
*   **Input Suppression (`ClientInputMixin`):**
    *   I introduced a new Mixin for `ClientInput`. It intercepts `getMoveVector()` and `hasForwardImpulse()`.
    *   Instead of freezing the player entity physics (which breaks Baritone's AI), we now suppress the user's manual WASD input at the source.
    *   **Smart Bypass:** The input suppression automatically disables itself when `freecam.isBaritonePathing()` is true. This allows the bot to control the player freely while the user flies around with the camera.
*   **Reflection Strategy:** The Baritone detection uses `Class.forName("baritone.api.BaritoneAPI")` and Method Reflection. This ensures a **soft dependency**. The client will not crash if Baritone is not installed or removed

| Feature | Legacy Behavior | New Compatibility Mode |
| :--- | :--- | :--- |
| **Physics** | Player frozen (Desync) | Player active, user input suppressed |
| **Baritone** | Breaks pathing/mining | Works fully while spectating |
| **Visuals** | Tracer lines to FakePlayer | Tracer lines to Real Player + Look Vector |

## Testing
I have tested this on the latest Wurst build with Baritone installed.

**Test Cases:**
1.  **Standard Freecam:** Works exactly as before (legacy mode remains default if unchecked).
2.  **Compatibility Mode (Idle):** Enabled Freecam. Player stays still. Camera moves freely. Gravity still applies to the player.
3.  **Compatibility Mode (Baritone):**
    *   Started a Baritone path (`#goto X Z`).
    *   Enabled Freecam.
    *   **Result:** The player continues walking/jumping/mining towards the goal. The camera flies independently.
    *   **Visuals:** The Tracer line correctly follows the moving player.

**Testing Tips:**
*   **Baritone Setup:** At the time of writing, the Baritone version for 1.21.1 is not available as a direct download. You will need to build it manually by switching to the appropriate branch in the Baritone repository.
*   **Head Rotation:** If you notice the bot is moving but the head isn't rotating correctly, try running **`#freelook false`** in Baritone. This forces Baritone to synchronize the player's head rotation with its movement direction.

## References
I have attached two videos demonstrating the difference:
1.  **Video 1 (Before):** Shows how Baritone stops working immediately when legacy Freecam is enabled
https://youtu.be/BWwD8kr5c20
2.  **Video 2 (After):** Shows the new Compatibility Mode, allowing the bot to continue working while I spectate
https://youtu.be/d-u0L2XbfK4
I apologize for using YouTube links instead of direct uploads. The video files were slightly larger than GitHub's 10MB limit, so I had to host them externally
