### PR TITLE
Fix .annoy command toggle logic

### DIFF
--- a/src/main/java/net/wurstclient/commands/AnnoyCmd.java
+++ b/src/main/java/net/wurstclient/commands/AnnoyCmd.java
@@ -41,6 +41,14 @@ public final class AnnoyCmd extends Command implements ChatInputListener
 	{
 		if(args.length > 0)
 		{
+			String newTarget = String.join(" ", args);
+			
+			if(enabled && target != null && target.equalsIgnoreCase(newTarget))
+			{
+				disable();
+				return;
+			}
+			
 			if(enabled)
 				disable();
 			
@@ -71,7 +79,7 @@ public final class AnnoyCmd extends Command implements ChatInputListener
 		enabled = true;
 	}
 	
-	private void disable() throws CmdException
+	private void disable()
 	{
 		EVENTS.remove(ChatInputListener.class, this);
 		


### PR DESCRIPTION
### Description
Fixed a bug where the `.annoy` command would immediately re-enable itself when trying to disable it if arguments were provided

The logic now checks if the target player is the same as the current one. If so, it only performs the disable action and returns early, preventing the immediate re-enable

### Related Issue
Fixes #1272

### Credit
Bug originally reported by @nerdnessly4922 in #1272