### PR TITLE
New "NoJumpDelay" hack

### DIFF
--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -138,6 +138,7 @@ public final class HackList implements UpdateListener
 	public final NoFireOverlayHack noFireOverlayHack = new NoFireOverlayHack();
 	public final NoFogHack noFogHack = new NoFogHack();
 	public final NoHurtcamHack noHurtcamHack = new NoHurtcamHack();
+	public final NoJumpDelayHack noJumpDelayHack = new NoJumpDelayHack();
 	public final NoLevitationHack noLevitationHack = new NoLevitationHack();
 	public final NoOverlayHack noOverlayHack = new NoOverlayHack();
 	public final NoPumpkinHack noPumpkinHack = new NoPumpkinHack();

--- a/src/main/java/net/wurstclient/hacks/NoJumpDelayHack.java
+++ b/src/main/java/net/wurstclient/hacks/NoJumpDelayHack.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.hacks;
+
+import net.wurstclient.Category;
+import net.wurstclient.hack.Hack;
+
+public final class NoJumpDelayHack extends Hack
+{
+	public NoJumpDelayHack()
+	{
+		super("NoJumpDelay");
+		setCategory(Category.MOVEMENT);
+	}
+	
+}

--- a/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/wurstclient/mixin/LivingEntityMixin.java
@@ -9,7 +9,9 @@ package net.wurstclient.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.core.Holder;
@@ -21,6 +23,7 @@ import net.wurstclient.WurstClient;
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin
 {
+	
 	/**
 	 * Stops the other darkness effect in caves when AntiBlind is enabled.
 	 */
@@ -36,4 +39,14 @@ public class LivingEntityMixin
 		if(WurstClient.INSTANCE.getHax().antiBlindHack.isEnabled())
 			cir.setReturnValue(0F);
 	}
+	
+	@ModifyConstant(method = "aiStep",
+		constant = @Constant(intValue = 10, ordinal = 0))
+	private int removeJumpDelay(int original)
+	{
+		if(WurstClient.INSTANCE.getHax().noJumpDelayHack.isEnabled())
+			return 0;
+		return original;
+	}
+	
 }

--- a/src/main/resources/assets/wurst/translations/en_us.json
+++ b/src/main/resources/assets/wurst/translations/en_us.json
@@ -217,6 +217,7 @@
   "description.wurst.hack.nofireoverlay": "Blocks the overlay when you are on fire.\n\n§c§lWARNING:§r This can cause you to burn to death without noticing.",
   "description.wurst.hack.nofog": "Removes distance fog from the world.",
   "description.wurst.hack.nohurtcam": "Disables the shaking effect when you get hurt.",
+  "description.wurst.hack.nojumpdelay": "Removes the cooldown between jumps.",
   "description.wurst.hack.nolevitation": "Disables the levitation effect when you get hit by a Shulker.\n\n§c§lWARNING:§r You will fall if you activate this while the levitation effect is already active!",
   "description.wurst.hack.nooverlay": "Blocks the overlays of water, lava, and powder snow.",
   "description.wurst.hack.nopumpkin": "Blocks the overlay when wearing a pumpkin on your head.",


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
Add new hack called "NoJumpDelay" which removes the 10 tick cooldown between jumps

## Testing
Singleplayer and Multiplayer with no issues 

## References
I dont think there is any im aware of
