### PR TITLE
attribute swap

### DIFF
--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -42,6 +42,7 @@ public final class HackList implements UpdateListener
 	public final AntiWaterPushHack antiWaterPushHack = new AntiWaterPushHack();
 	public final AntiWobbleHack antiWobbleHack = new AntiWobbleHack();
 	public final ArrowDmgHack arrowDmgHack = new ArrowDmgHack();
+	public final AttributeSwapHack attributeSwapHack = new AttributeSwapHack();
 	public final AutoArmorHack autoArmorHack = new AutoArmorHack();
 	public final AutoBuildHack autoBuildHack = new AutoBuildHack();
 	public final AutoCompleteHack autoCompleteHack = new AutoCompleteHack();

--- a/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
+++ b/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2014-2026 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.hacks;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.*;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.wurstclient.Category;
+import net.wurstclient.SearchTags;
+import net.wurstclient.events.PlayerAttacksEntityListener;
+import net.wurstclient.events.UpdateListener;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.settings.CheckboxSetting;
+import net.wurstclient.settings.EnumSetting;
+import net.wurstclient.settings.SliderSetting;
+import net.wurstclient.settings.SliderSetting.ValueDisplay;
+import net.wurstclient.util.InventoryUtils;
+
+@SearchTags({"attribute swap", "weapon swap", "auto breach swap", "breach swap",
+	"mace swap", "auto swap", "auto shield break", "auto mace", "shield break",
+	"disable shield", "item swap", "hotbar swap", "item saver",
+	"durability saver"})
+public final class AttributeSwapHack extends Hack
+	implements PlayerAttacksEntityListener, UpdateListener
+{
+	private final EnumSetting<Mode> mode = new EnumSetting<>("Mode",
+		"Simple: swaps to a fixed hotbar slot on attack.\n"
+			+ "Smart: checks target and picks the best item automatically.",
+		Mode.values(), Mode.Simple);
+	
+	private final SliderSetting targetSlot = new SliderSetting("Target slot",
+		"Hotbar slot to swap to (Simple mode).", 1, 1, 9, 1,
+		ValueDisplay.INTEGER);
+	
+	private final CheckboxSetting swapBack = new CheckboxSetting("Swap back",
+		"Swap back to the original slot after delay.", true);
+	
+	private final SliderSetting swapBackDelay =
+		new SliderSetting("Swap-back delay",
+			"How many ticks to wait before swapping back.", 2, 0, 20, 1,
+			ValueDisplay.INTEGER.withSuffix(" ticks").withLabel(0, "instant"));
+	
+	private final CheckboxSetting breachSwapping = new CheckboxSetting(
+		"Breach swapping",
+		"Swaps to a mace with Breach to deal more damage (Smart mode).", true);
+	
+	private final CheckboxSetting shieldBreaker =
+		new CheckboxSetting("Shield breaker",
+			"Swaps to an axe when target is blocking (Smart mode).", true);
+	
+	private final CheckboxSetting itemSaver = new CheckboxSetting("Item saver",
+		"Swaps to a non-damageable item to save main weapon durability (Smart mode).",
+		true);
+	
+	private final CheckboxSetting onlyWithKillAura = new CheckboxSetting(
+		"Only with KillAura", "Only activate when KillAura is enabled.", false);
+	
+	private int backTimer;
+	private boolean awaitingBack;
+	private int originalSlot;
+	
+	public AttributeSwapHack()
+	{
+		super("AttributeSwap");
+		setCategory(Category.COMBAT);
+		
+		addSetting(mode);
+		addSetting(targetSlot);
+		addSetting(swapBack);
+		addSetting(swapBackDelay);
+		addSetting(shieldBreaker);
+		addSetting(itemSaver);
+		addSetting(breachSwapping);
+		addSetting(onlyWithKillAura);
+	}
+	
+	@Override
+	protected void onEnable()
+	{
+		backTimer = 0;
+		awaitingBack = false;
+		originalSlot = -1;
+		EVENTS.add(PlayerAttacksEntityListener.class, this);
+		EVENTS.add(UpdateListener.class, this);
+	}
+	
+	@Override
+	protected void onDisable()
+	{
+		EVENTS.remove(PlayerAttacksEntityListener.class, this);
+		EVENTS.remove(UpdateListener.class, this);
+		
+		if(awaitingBack)
+		{
+			doSwapBack();
+			awaitingBack = false;
+		}
+		backTimer = 0;
+		originalSlot = -1;
+	}
+	
+	@Override
+	public void onPlayerAttacksEntity(Entity target)
+	{
+		
+		if(onlyWithKillAura.isChecked()
+			&& !WURST.getHax().killauraHack.isEnabled())
+			return;
+		
+		performSwap(target);
+	}
+	
+	@Override
+	public void onUpdate()
+	{
+		if(!awaitingBack)
+			return;
+		if(backTimer-- > 0)
+			return;
+		doSwapBack();
+		awaitingBack = false;
+	}
+	
+	private void performSwap(Entity target)
+	{
+		if(awaitingBack)
+			return;
+		
+		if(mode.getSelected() == Mode.Simple)
+		{
+			doSwap((int)targetSlot.getValue() - 1);
+			return;
+		}
+		
+		doSwap(getSmartSlot(target));
+	}
+	
+	private void doSwap(int slotIndex)
+	{
+		if(awaitingBack)
+			return;
+		if(slotIndex < 0 || slotIndex > 8)
+			return;
+		
+		int current = MC.player.getInventory().getSelectedSlot();
+		if(slotIndex == current)
+			return;
+		
+		originalSlot = current;
+		MC.player.getInventory().setSelectedSlot(slotIndex);
+		
+		if(swapBack.isChecked())
+		{
+			awaitingBack = true;
+			backTimer = (int)swapBackDelay.getValue();
+		}
+	}
+	
+	private void doSwapBack()
+	{
+		if(originalSlot >= 0 && originalSlot <= 8)
+			MC.player.getInventory().setSelectedSlot(originalSlot);
+		originalSlot = -1;
+	}
+	
+	private int getSmartSlot(Entity target)
+	{
+		ItemStack current = MC.player.getMainHandItem();
+		
+		if(target instanceof LivingEntity living && shieldBreaker.isChecked()
+			&& living.isBlocking())
+		{
+			if(current.getItem() instanceof AxeItem)
+				return -1;
+			int axeSlot =
+				InventoryUtils.indexOf(s -> s.getItem() instanceof AxeItem, 9);
+			if(axeSlot != -1)
+				return axeSlot;
+		}
+		
+		if(target instanceof LivingEntity living && breachSwapping.isChecked())
+		{
+			double armor = living.getAttributeValue(
+				net.minecraft.world.entity.ai.attributes.Attributes.ARMOR);
+			if(armor > 0)
+			{
+				int breachSlot =
+					InventoryUtils
+						.indexOf(
+							s -> s.getItem() instanceof MaceItem
+								&& getEnchantLevel(s, Enchantments.BREACH) > 0,
+							9);
+				if(breachSlot != -1)
+					return breachSlot;
+			}
+		}
+		
+		boolean durability = itemSaver.isChecked();
+		
+		int bestSlot = -1;
+		double bestScore = getDurabilityScore(current, durability);
+		
+		for(int i = 0; i < 9; i++)
+		{
+			if(i == MC.player.getInventory().getSelectedSlot())
+				continue;
+			
+			ItemStack stack = MC.player.getInventory().getItem(i);
+			if(stack.isEmpty())
+				continue;
+			
+			double score = getDurabilityScore(stack, durability);
+			
+			if(score > bestScore)
+			{
+				bestScore = score;
+				bestSlot = i;
+			}
+		}
+		
+		return bestSlot;
+	}
+	
+	private double getDurabilityScore(ItemStack stack, boolean durability)
+	{
+		if(!durability)
+			return 0;
+		if(!stack.isDamageableItem())
+			return 4;
+		
+		return 0;
+	}
+	
+	private int getEnchantLevel(ItemStack stack,
+		net.minecraft.resources.ResourceKey<net.minecraft.world.item.enchantment.Enchantment> key)
+	{
+		if(MC.level == null)
+			return 0;
+		
+		return MC.level.registryAccess()
+			.lookup(net.minecraft.core.registries.Registries.ENCHANTMENT)
+			.flatMap(reg -> reg.get(key)).map(holder -> EnchantmentHelper
+				.getItemEnchantmentLevel(holder, stack))
+			.orElse(0);
+	}
+	
+	public enum Mode
+	{
+		Simple("Simple"),
+		Smart("Smart");
+		
+		private final String name;
+		
+		Mode(String name)
+		{
+			this.name = name;
+		}
+		
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+}

--- a/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
+++ b/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
@@ -60,7 +60,7 @@ public final class AttributeSwapHack extends Hack
 		true);
 	
 	private final CheckboxSetting onlyWithKillAura = new CheckboxSetting(
-		"Only with KillAura", "Only activate when KillAura is enabled.", false);
+		"Only with Killaura", "Only activate when Killaura is enabled.", false);
 	
 	private int backTimer;
 	private boolean awaitingBack;

--- a/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
+++ b/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
@@ -7,9 +7,15 @@
  */
 package net.wurstclient.hacks;
 
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.*;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.item.AxeItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.MaceItem;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.wurstclient.Category;
@@ -33,7 +39,7 @@ public final class AttributeSwapHack extends Hack
 	private final EnumSetting<Mode> mode = new EnumSetting<>("Mode",
 		"Simple: swaps to a fixed hotbar slot on attack.\n"
 			+ "Smart: checks target and picks the best item automatically.",
-		Mode.values(), Mode.Simple);
+		Mode.values(), Mode.SIMPLE);
 	
 	private final SliderSetting targetSlot = new SliderSetting("Target slot",
 		"Hotbar slot to swap to (Simple mode).", 1, 1, 9, 1,
@@ -70,7 +76,6 @@ public final class AttributeSwapHack extends Hack
 	{
 		super("AttributeSwap");
 		setCategory(Category.COMBAT);
-		
 		addSetting(mode);
 		addSetting(targetSlot);
 		addSetting(swapBack);
@@ -87,6 +92,7 @@ public final class AttributeSwapHack extends Hack
 		backTimer = 0;
 		awaitingBack = false;
 		originalSlot = -1;
+		
 		EVENTS.add(PlayerAttacksEntityListener.class, this);
 		EVENTS.add(UpdateListener.class, this);
 	}
@@ -109,7 +115,6 @@ public final class AttributeSwapHack extends Hack
 	@Override
 	public void onPlayerAttacksEntity(Entity target)
 	{
-		
 		if(onlyWithKillAura.isChecked()
 			&& !WURST.getHax().killauraHack.isEnabled())
 			return;
@@ -124,6 +129,7 @@ public final class AttributeSwapHack extends Hack
 			return;
 		if(backTimer-- > 0)
 			return;
+		
 		doSwapBack();
 		awaitingBack = false;
 	}
@@ -133,9 +139,9 @@ public final class AttributeSwapHack extends Hack
 		if(awaitingBack)
 			return;
 		
-		if(mode.getSelected() == Mode.Simple)
+		if(mode.getSelected() == Mode.SIMPLE)
 		{
-			doSwap((int)targetSlot.getValue() - 1);
+			doSwap(targetSlot.getValueI() - 1);
 			return;
 		}
 		
@@ -159,7 +165,7 @@ public final class AttributeSwapHack extends Hack
 		if(swapBack.isChecked())
 		{
 			awaitingBack = true;
-			backTimer = (int)swapBackDelay.getValue();
+			backTimer = swapBackDelay.getValueI();
 		}
 	}
 	
@@ -167,6 +173,7 @@ public final class AttributeSwapHack extends Hack
 	{
 		if(originalSlot >= 0 && originalSlot <= 8)
 			MC.player.getInventory().setSelectedSlot(originalSlot);
+		
 		originalSlot = -1;
 	}
 	
@@ -179,58 +186,50 @@ public final class AttributeSwapHack extends Hack
 		{
 			if(current.getItem() instanceof AxeItem)
 				return -1;
+			
 			int axeSlot =
 				InventoryUtils.indexOf(s -> s.getItem() instanceof AxeItem, 9);
 			if(axeSlot != -1)
 				return axeSlot;
 		}
 		
-		if(target instanceof LivingEntity living && breachSwapping.isChecked())
+		if(breachSwapping.isChecked() && target instanceof LivingEntity le
+			&& le.getAttributes().getValue(Attributes.ARMOR) > 0)
 		{
-			double armor = living.getAttributeValue(
-				net.minecraft.world.entity.ai.attributes.Attributes.ARMOR);
-			if(armor > 0)
-			{
-				int breachSlot =
-					InventoryUtils
-						.indexOf(
-							s -> s.getItem() instanceof MaceItem
-								&& getEnchantLevel(s, Enchantments.BREACH) > 0,
-							9);
-				if(breachSlot != -1)
-					return breachSlot;
-			}
+			int breachSlot =
+				InventoryUtils.indexOf(s -> s.getItem() instanceof MaceItem
+					&& getEnchantLevel(s, Enchantments.BREACH) > 0, 9);
+			
+			if(breachSlot != -1)
+				return breachSlot;
 		}
 		
-		boolean durability = itemSaver.isChecked();
-		
 		int bestSlot = -1;
-		double bestScore = getDurabilityScore(current, durability);
+		int bestScore = getDurabilityScore(current);
 		
-		for(int i = 0; i < 9; i++)
+		for(int slot = 0; slot < 9; slot++)
 		{
-			if(i == MC.player.getInventory().getSelectedSlot())
+			if(slot == MC.player.getInventory().getSelectedSlot())
 				continue;
 			
-			ItemStack stack = MC.player.getInventory().getItem(i);
+			ItemStack stack = MC.player.getInventory().getItem(slot);
 			if(stack.isEmpty())
 				continue;
 			
-			double score = getDurabilityScore(stack, durability);
-			
+			int score = getDurabilityScore(stack);
 			if(score > bestScore)
 			{
 				bestScore = score;
-				bestSlot = i;
+				bestSlot = slot;
 			}
 		}
 		
 		return bestSlot;
 	}
 	
-	private double getDurabilityScore(ItemStack stack, boolean durability)
+	private int getDurabilityScore(ItemStack stack)
 	{
-		if(!durability)
+		if(!itemSaver.isChecked())
 			return 0;
 		if(!stack.isDamageableItem())
 			return 4;
@@ -238,27 +237,25 @@ public final class AttributeSwapHack extends Hack
 		return 0;
 	}
 	
-	private int getEnchantLevel(ItemStack stack,
-		net.minecraft.resources.ResourceKey<net.minecraft.world.item.enchantment.Enchantment> key)
+	private int getEnchantLevel(ItemStack stack, ResourceKey<Enchantment> key)
 	{
 		if(MC.level == null)
 			return 0;
 		
-		return MC.level.registryAccess()
-			.lookup(net.minecraft.core.registries.Registries.ENCHANTMENT)
+		return MC.level.registryAccess().lookup(Registries.ENCHANTMENT)
 			.flatMap(reg -> reg.get(key)).map(holder -> EnchantmentHelper
 				.getItemEnchantmentLevel(holder, stack))
 			.orElse(0);
 	}
 	
-	public enum Mode
+	private enum Mode
 	{
-		Simple("Simple"),
-		Smart("Smart");
+		SIMPLE("Simple"),
+		SMART("Smart");
 		
 		private final String name;
 		
-		Mode(String name)
+		private Mode(String name)
 		{
 			this.name = name;
 		}

--- a/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
+++ b/src/main/java/net/wurstclient/hacks/AttributeSwapHack.java
@@ -29,10 +29,9 @@ import net.wurstclient.settings.SliderSetting;
 import net.wurstclient.settings.SliderSetting.ValueDisplay;
 import net.wurstclient.util.InventoryUtils;
 
-@SearchTags({"attribute swap", "weapon swap", "auto breach swap", "breach swap",
-	"mace swap", "auto swap", "auto shield break", "auto mace", "shield break",
-	"disable shield", "item swap", "hotbar swap", "item saver",
-	"durability saver"})
+@SearchTags({"attribute swap", "weapon swap", "auto breach swap", "mace swap",
+	"auto swap", "auto shield break", "auto mace", "disable shield",
+	"item swap", "hotbar swap", "item saver", "durability saver"})
 public final class AttributeSwapHack extends Hack
 	implements PlayerAttacksEntityListener, UpdateListener
 {

--- a/src/main/resources/assets/wurst/translations/en_us.json
+++ b/src/main/resources/assets/wurst/translations/en_us.json
@@ -32,6 +32,7 @@
   "description.wurst.hack.arrowdmg": "Massively increases arrow damage, but also consumes a lot of hunger and reduces accuracy.\n\nDoes not work with crossbows and seems to be patched on Paper servers.",
   "description.wurst.setting.arrowdmg.strength": "Strength of the effect. 10 is the highest possible as of Minecraft 1.21.",
   "description.wurst.setting.arrowdmg.trident_yeet_mode": "When enabled, tridents fly much further. Doesn't seem to affect damage or Riptide.\n\n§c§lWARNING:§r You can easily lose your trident by enabling this option!",
+  "description.wurst.hack.attributeswap": "Swaps main-hand item attributes with the target slot.",
   "description.wurst.hack.autoarmor": "Manages your armor automatically.",
   "description.wurst.hack.autobuild": "Builds things automatically.\nPlace a single block to start building.",
   "description.wurst.setting.autobuild.face_target": "How AutoBuild should face the blocks it's placing.",


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
add most requested hack: attribute swap 
works by quickly swapping your main item with the desired item slot you want
this lets you to combine the base damage and attack cooldown of your first item with the attributes (enchanments/special properties) of the swapped item

## Testing
singleplayer using carpet mod for fake test players

here a couple of videos showcasing the hack:



https://github.com/user-attachments/assets/4db18787-8175-475b-8373-ddaaa91ea4bd


https://github.com/user-attachments/assets/497d5453-b745-4728-8ebc-311cf357031b

(forgot to show but my axe is at 1 use left)

https://github.com/user-attachments/assets/1e9eb878-723f-4bae-b161-7f8b6de387fd


https://github.com/user-attachments/assets/28d5e2b0-668c-422d-9443-2a0229b18d20


 

## References

#1305
#1275

1. https://wurstforum.net/d/982
2. https://wurstforum.net/d/1004
3. https://wurstforum.net/d/1177
4. https://wurstforum.net/d/1402
5. https://wurstforum.net/d/1456
6. https://wurstforum.net/d/1471
7. https://wurstforum.net/d/1493
8. https://wurstforum.net/d/1501
